### PR TITLE
Add AsyncAws compatibility matrix

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,6 @@ jobs:
   build:
     name: PHP ${{ matrix.php-version }} / async-aws/dynamo-db ${{ matrix.async-aws-dynamo-db }}
     runs-on: ubuntu-latest
-    container: ubuntu:latest
     services:
       dynamodb-local:
         image: amazon/dynamodb-local:1.22.0
@@ -48,13 +47,10 @@ jobs:
     env: 
       AWS_ACCESS_KEY_ID: 'none'
       AWS_SECRET_ACCESS_KEY: 'none'
+      DYNAMODB_ENDPOINT: 'http://127.0.0.1:8000'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Install git
-        run: |
-          apt-get update && apt-get install -y --no-install-recommends git
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build:
-    name: PHP ${{ matrix.php-versions }}
+    name: PHP ${{ matrix.php-version }} / async-aws/dynamo-db ${{ matrix.async-aws-dynamo-db }}
     runs-on: ubuntu-latest
     container: ubuntu:latest
     services:
@@ -18,8 +18,33 @@ jobs:
         ports:
           - 8000:8000/tcp
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        include:
+          - php-version: '8.2'
+            async-aws-dynamo-db: '^1.3.0'
+          - php-version: '8.2'
+            async-aws-dynamo-db: '^2.0.0'
+          - php-version: '8.2'
+            async-aws-dynamo-db: '^3.0.0'
+          - php-version: '8.3'
+            async-aws-dynamo-db: '^1.3.0'
+          - php-version: '8.3'
+            async-aws-dynamo-db: '^2.0.0'
+          - php-version: '8.3'
+            async-aws-dynamo-db: '^3.0.0'
+          - php-version: '8.4'
+            async-aws-dynamo-db: '^1.3.0'
+          - php-version: '8.4'
+            async-aws-dynamo-db: '^2.0.0'
+          - php-version: '8.4'
+            async-aws-dynamo-db: '^3.0.0'
+          - php-version: '8.5'
+            async-aws-dynamo-db: '^1.3.0'
+          - php-version: '8.5'
+            async-aws-dynamo-db: '^2.0.0'
+          - php-version: '8.5'
+            async-aws-dynamo-db: '^3.0.0'
     env: 
       AWS_ACCESS_KEY_ID: 'none'
       AWS_SECRET_ACCESS_KEY: 'none'
@@ -34,7 +59,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           tools: composer
           coverage: xdebug
 
@@ -46,12 +71,14 @@ jobs:
         uses: actions/cache@v5
         with:
           path: vendor
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-dynamodb-${{ matrix.async-aws-dynamo-db }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-
+            ${{ runner.os }}-php-${{ matrix.php-version }}-dynamodb-${{ matrix.async-aws-dynamo-db }}-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: |
+          composer require async-aws/dynamo-db:${{ matrix.async-aws-dynamo-db }} --no-update
+          composer update --prefer-dist --no-progress
 
       - name: Run phpunit
         run: composer run-script phpunit

--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# DynamoDB Read Model
+
+A DynamoDB-backed Broadway read model repository.
+
+## Installation
+
+```bash
+composer require chrisjenkinson/dynamo-db-read-model
+```
+
+The package supports `async-aws/dynamo-db` `^1.3`, `^2.0`, and `^3.0`.
+
+## DynamoDB Table
+
+Create one table for the read model store. The table uses a composite primary
+key:
+
+| Attribute | Type | Key | Description |
+| --- | --- | --- | --- |
+| `Name` | String | Partition | Repository name passed to `RepositoryFactory::create()` |
+| `Id` | String | Sort | Read model identifier from `Identifiable::getId()` |
+| `Data` | String | - | JSON-encoded serialized read model payload |
+
+The library queries by `Name` to load all read models for a repository, and uses
+`Name` + `Id` for single-item reads, writes, and deletes. It does not require
+secondary indexes.
+
+Example AWS CLI setup:
+
+```bash
+aws dynamodb create-table \
+  --table-name read-models \
+  --billing-mode PAY_PER_REQUEST \
+  --attribute-definitions \
+    AttributeName=Name,AttributeType=S \
+    AttributeName=Id,AttributeType=S \
+  --key-schema \
+    AttributeName=Name,KeyType=HASH \
+    AttributeName=Id,KeyType=RANGE
+```
+
+## Testing
+
+The test suite expects DynamoDB Local. In GitHub Actions this is provided as a
+service named `dynamodb-local`; locally, override the endpoint:
+
+```bash
+DYNAMODB_ENDPOINT=http://127.0.0.1:8000 \
+AWS_ACCESS_KEY_ID=none \
+AWS_SECRET_ACCESS_KEY=none \
+composer run-script phpunit
+```
+
+CI tests supported PHP versions against each supported AsyncAws DynamoDB major.
+
+## Quality Checks
+
+```bash
+vendor/bin/ecs check --config ecs.php
+composer run-script phpstan
+composer run-script infection
+```

--- a/composer.json
+++ b/composer.json
@@ -3,12 +3,12 @@
     "description": "A DynamoDB ReadModel implementation for Broadway.",
     "type": "library",
     "require": {
-        "async-aws/dynamo-db": "^1.3.0 || ^3.0.0",
+        "async-aws/dynamo-db": "^1.3.0 || ^2.0.0 || ^3.0.0",
         "broadway/broadway": "^2.4.0",
         "ext-json": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5.0 || ^13.0.0",
+        "phpunit/phpunit": "^9.5.0",
         "symplify/easy-coding-standard": "^11.1.0 || ^12.0.0 || ^13.0.0",
         "phpstan/phpstan": "^1.8.0",
         "infection/infection": "^0.26.0 || ^0.32.0"

--- a/ecs.php
+++ b/ecs.php
@@ -22,7 +22,6 @@ return static function (ECSConfig $ecsConfig): void {
         SetList::ARRAY,
         SetList::DOCBLOCK,
         SetList::PSR_12,
-        SetList::STRICT,
     ]);
 
     $ecsConfig->ruleWithConfiguration(ArraySyntaxFixer::class, [

--- a/src/DynamoDbRepository.php
+++ b/src/DynamoDbRepository.php
@@ -8,10 +8,10 @@ use AsyncAws\DynamoDb\DynamoDbClient;
 use Broadway\ReadModel\Identifiable;
 use Broadway\ReadModel\Repository;
 use Broadway\Serializer\Serializer;
-use ReflectionClass;
+use chrisjenkinson\DynamoDbReadModel\Exception\CannotFilterWithNonexistentKey;
 use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedEncodedData;
 use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
-use chrisjenkinson\DynamoDbReadModel\Exception\CannotFilterWithNonexistentKey;
+use ReflectionClass;
 
 final class DynamoDbRepository implements Repository
 {

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -19,9 +19,9 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
     protected function createRepository(): Repository
     {
         $client = new DynamoDbClient(Configuration::create([
-            'endpoint'        => 'http://dynamodb-local:8000',
-            'accessKeyId'     => '',
-            'accessKeySecret' => '',
+            'endpoint'        => getenv('DYNAMODB_ENDPOINT') ?: 'http://dynamodb-local:8000',
+            'accessKeyId'     => getenv('AWS_ACCESS_KEY_ID') ?: 'none',
+            'accessKeySecret' => getenv('AWS_SECRET_ACCESS_KEY') ?: 'none',
         ]));
         $tableName = 'table';
 


### PR DESCRIPTION
This updates the package to advertise support for async-aws/dynamo-db v1, v2, and v3, and expands CI to test each supported AsyncAws DynamoDB major across the currently supported PHP versions.

It also adds a short README covering installation, the required DynamoDB table structure, local DynamoDB endpoint configuration for tests, and the project quality commands.