### PR TITLE
Validate read model class before deserialization

### DIFF
--- a/src/DynamoDbRepository.php
+++ b/src/DynamoDbRepository.php
@@ -52,13 +52,7 @@ final class DynamoDbRepository implements Repository
             throw new UnexpectedEncodedData('Data', 'string', $encodedData);
         }
 
-        $data = $this->serializer->deserialize($this->jsonDecoder->decode($encodedData));
-
-        if (!($data instanceof $this->class && $data instanceof Identifiable)) {
-            throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
-        }
-
-        return $data;
+        return $this->deserializeReadModel($encodedData);
     }
 
     /**
@@ -85,13 +79,7 @@ final class DynamoDbRepository implements Repository
                 throw new UnexpectedEncodedData('Data', 'string', $encodedData);
             }
 
-            $data = $this->serializer->deserialize($this->jsonDecoder->decode($encodedData));
-
-            if (!($data instanceof $this->class && $data instanceof Identifiable)) {
-                throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
-            }
-
-            $items[] = $data;
+            $items[] = $this->deserializeReadModel($encodedData);
         }
 
         $items = array_filter($items, function (Identifiable $model) use ($fields): bool {
@@ -148,13 +136,7 @@ final class DynamoDbRepository implements Repository
                 throw new UnexpectedEncodedData('Data', 'string', $encodedData);
             }
 
-            $data = $this->serializer->deserialize($this->jsonDecoder->decode($encodedData));
-
-            if (!($data instanceof $this->class && $data instanceof Identifiable)) {
-                throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
-            }
-
-            $items[] = $data;
+            $items[] = $this->deserializeReadModel($encodedData);
         }
 
         return $items;
@@ -163,5 +145,39 @@ final class DynamoDbRepository implements Repository
     public function remove($id): void
     {
         $this->client->deleteItem($this->inputBuilder->buildDeleteItemInput($this->table, $this->name, (string) $id));
+    }
+
+    private function deserializeReadModel(string $encodedData): Identifiable
+    {
+        $serializedData = $this->jsonDecoder->decode($encodedData);
+
+        if (!isset($serializedData['class']) || !is_string($serializedData['class'])) {
+            throw new UnexpectedReadModel(actual: $this->describeSerializedClass($serializedData['class'] ?? null), expected: $this->class);
+        }
+
+        if ($serializedData['class'] !== $this->class) {
+            throw new UnexpectedReadModel(actual: $serializedData['class'], expected: $this->class);
+        }
+
+        $data = $this->serializer->deserialize($serializedData);
+
+        if (!($data instanceof $this->class && $data instanceof Identifiable)) {
+            throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
+        }
+
+        return $data;
+    }
+
+    private function describeSerializedClass(mixed $class): string
+    {
+        if (is_string($class)) {
+            return $class;
+        }
+
+        if (is_scalar($class) || null === $class) {
+            return var_export($class, true);
+        }
+
+        return get_debug_type($class);
     }
 }

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -6,33 +6,34 @@ namespace chrisjenkinson\DynamoDbReadModel\Tests;
 
 use AsyncAws\Core\Configuration;
 use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use Broadway\ReadModel\Repository;
 use Broadway\ReadModel\Testing\RepositoryTestCase;
 use Broadway\ReadModel\Testing\RepositoryTestReadModel;
 use Broadway\Serializer\SimpleInterfaceSerializer;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbRepositoryFactory;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbTableManager;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
 use chrisjenkinson\DynamoDbReadModel\InputBuilder;
 
 final class DynamoDbRepositoryTest extends RepositoryTestCase
 {
+    private const TABLE_NAME = 'table';
+
+    private const REPOSITORY_NAME = 'name';
+
     protected function createRepository(): Repository
     {
-        $client = new DynamoDbClient(Configuration::create([
-            'endpoint'        => getenv('DYNAMODB_ENDPOINT') ?: 'http://dynamodb-local:8000',
-            'accessKeyId'     => getenv('AWS_ACCESS_KEY_ID') ?: 'none',
-            'accessKeySecret' => getenv('AWS_SECRET_ACCESS_KEY') ?: 'none',
-        ]));
-        $tableName = 'table';
+        $client = $this->createDynamoDbClient();
 
-        $tableManager = new DynamoDbTableManager($client, new InputBuilder(), $tableName);
+        $tableManager = new DynamoDbTableManager($client, new InputBuilder(), self::TABLE_NAME);
         $serializer   = new SimpleInterfaceSerializer();
-        $factory      = new DynamoDbRepositoryFactory($client, $serializer, $tableName);
+        $factory      = new DynamoDbRepositoryFactory($client, $serializer, self::TABLE_NAME);
 
         $tableManager->deleteTable();
         $tableManager->createTable();
 
-        return $factory->create('name', RepositoryTestReadModel::class);
+        return $factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class);
     }
 
     /**
@@ -49,5 +50,50 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         $this->repository->remove(1);
 
         $this->assertEquals([$model2], $this->repository->findAll());
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_unexpected_serialized_classes_before_deserializing_them(): void
+    {
+        UnexpectedSerializableReadModel::$deserializeWasCalled = false;
+
+        $this->createDynamoDbClient()->putItem([
+            'TableName' => self::TABLE_NAME,
+            'Item'      => [
+                'Name' => new AttributeValue([
+                    'S' => self::REPOSITORY_NAME,
+                ]),
+                'Id' => new AttributeValue([
+                    'S' => 'unexpected',
+                ]),
+                'Data' => new AttributeValue([
+                    'S' => json_encode([
+                        'class'   => UnexpectedSerializableReadModel::class,
+                        'payload' => [
+                            'id' => 'unexpected',
+                        ],
+                    ], JSON_THROW_ON_ERROR),
+                ]),
+            ],
+        ])->resolve();
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        try {
+            $this->repository->find('unexpected');
+        } finally {
+            $this->assertFalse(UnexpectedSerializableReadModel::$deserializeWasCalled);
+        }
+    }
+
+    private function createDynamoDbClient(): DynamoDbClient
+    {
+        return new DynamoDbClient(Configuration::create([
+            'endpoint'        => getenv('DYNAMODB_ENDPOINT') ?: 'http://dynamodb-local:8000',
+            'accessKeyId'     => getenv('AWS_ACCESS_KEY_ID') ?: 'none',
+            'accessKeySecret' => getenv('AWS_SECRET_ACCESS_KEY') ?: 'none',
+        ]));
     }
 }

--- a/tests/UnexpectedSerializableReadModel.php
+++ b/tests/UnexpectedSerializableReadModel.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use Broadway\ReadModel\SerializableReadModel;
+
+final class UnexpectedSerializableReadModel implements SerializableReadModel
+{
+    public static bool $deserializeWasCalled = false;
+
+    public function __construct(
+        private readonly string $id
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function serialize(): array
+    {
+        return [
+            'id' => $this->id,
+        ];
+    }
+
+    /**
+     * @param array<string, string> $data
+     */
+    public static function deserialize(array $data)
+    {
+        self::$deserializeWasCalled = true;
+
+        return new self($data['id']);
+    }
+}


### PR DESCRIPTION
Adds a guard that checks the serialized Broadway read-model class matches the repository's expected class before deserializing DynamoDB data.

Includes a regression test that inserts a mismatched serialized class directly into DynamoDB and verifies its deserialize method is not called.