### PR TITLE
Resolve write operation responses

### DIFF
--- a/src/DynamoDbRepository.php
+++ b/src/DynamoDbRepository.php
@@ -33,7 +33,7 @@ final class DynamoDbRepository implements Repository
 
         $putItemInput = $this->inputBuilder->buildPutItemInput($this->table, $this->name, $data->getId(), $encodedData);
 
-        $this->client->putItem($putItemInput);
+        $this->client->putItem($putItemInput)->resolve();
     }
 
     public function find($id): ?Identifiable
@@ -144,7 +144,7 @@ final class DynamoDbRepository implements Repository
 
     public function remove($id): void
     {
-        $this->client->deleteItem($this->inputBuilder->buildDeleteItemInput($this->table, $this->name, (string) $id));
+        $this->client->deleteItem($this->inputBuilder->buildDeleteItemInput($this->table, $this->name, (string) $id))->resolve();
     }
 
     private function deserializeReadModel(string $encodedData): Identifiable

--- a/tests/DynamoDbRepositoryResponseResolutionTest.php
+++ b/tests/DynamoDbRepositoryResponseResolutionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Result\DeleteItemOutput;
+use AsyncAws\DynamoDb\Result\PutItemOutput;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbRepository;
+use chrisjenkinson\DynamoDbReadModel\InputBuilder;
+use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
+use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+final class DynamoDbRepositoryResponseResolutionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_resolves_the_put_item_response_when_saving(): void
+    {
+        $output = new PutItemOutput($this->createResponse());
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('putItem')->willReturn($output);
+
+        $this->createRepository($client)->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+
+        $this->assertTrue($output->info()['resolved']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_resolves_the_delete_item_response_when_removing(): void
+    {
+        $output = new DeleteItemOutput($this->createResponse());
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('deleteItem')->willReturn($output);
+
+        $this->createRepository($client)->remove('id');
+
+        $this->assertTrue($output->info()['resolved']);
+    }
+
+    private function createRepository(DynamoDbClient $client): DynamoDbRepository
+    {
+        return new DynamoDbRepository(
+            $client,
+            new InputBuilder(),
+            new SimpleInterfaceSerializer(),
+            new JsonEncoder(),
+            new JsonDecoder(),
+            'table',
+            'name',
+            RepositoryTestReadModel::class
+        );
+    }
+
+    private function createResponse(): Response
+    {
+        $client = new MockHttpClient(new SimpleMockedResponse('{}'));
+
+        return new Response($client->request('POST', 'http://localhost'), $client, new NullLogger());
+    }
+}


### PR DESCRIPTION
Forces AsyncAws putItem and deleteItem responses to resolve before save() and remove() return, so write/delete failures surface at the repository call site.

Adds unit coverage that asserts the returned AsyncAws outputs are resolved by the repository methods.