### PR TITLE
Add CI jobs for ECS and Infection

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -81,3 +81,70 @@ jobs:
 
       - name: Run phpstan
         run: composer run-script phpstan
+
+  ecs:
+    name: ECS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+          coverage: none
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-8.4-ecs-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-ecs-
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress
+
+      - name: Run ECS
+        run: vendor/bin/ecs check --config ecs.php
+
+  infection:
+    name: Infection
+    runs-on: ubuntu-latest
+    services:
+      dynamodb-local:
+        image: amazon/dynamodb-local:1.22.0
+        ports:
+          - 8000:8000/tcp
+    env:
+      AWS_ACCESS_KEY_ID: 'none'
+      AWS_SECRET_ACCESS_KEY: 'none'
+      DYNAMODB_ENDPOINT: 'http://127.0.0.1:8000'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+          coverage: xdebug
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-8.4-infection-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.4-infection-
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress
+
+      - name: Run Infection
+        run: composer run-script infection

--- a/infection.json5
+++ b/infection.json5
@@ -8,6 +8,8 @@
     "mutators": {
         "@default": true
     },
+    "minMsi": 95,
+    "minCoveredMsi": 95,
     "logs": {
         "text": "infection.log",
         "html": "infection.html"


### PR DESCRIPTION
Adds separate CI jobs for ECS and Infection so style and mutation testing are enforced outside the PHP/AsyncAws compatibility matrix.

Also sets Infection MSI and covered MSI thresholds to 95.