### PR TITLE
Suppress unchanged read model writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,38 @@ model, and then filters in PHP. For production-sized collections, avoid using
 `findAll()` or `findBy()` on request paths unless that full-partition work is
 intentional.
 
+## Snapshot Store
+
+This release changes the public constructors for `DynamoDbRepositoryFactory`
+and `DynamoDbRepository`.
+
+`DynamoDbRepositoryFactory` requires a `ReadModelSnapshotStore` so repositories
+created by the same factory can suppress unchanged physical writes without an
+extra DynamoDB read:
+
+```php
+$factory = new DynamoDbRepositoryFactory($client, $serializer, 'read-models', new ReadModelSnapshotStore());
+```
+
+Direct `DynamoDbRepository` construction also needs the same dependency:
+
+```php
+$repository = new DynamoDbRepository(
+    $client,
+    $inputBuilder,
+    $serializer,
+    $jsonEncoder,
+    $jsonDecoder,
+    'read-models',
+    'repository-name',
+    MyReadModel::class,
+    new ReadModelSnapshotStore()
+);
+```
+
+Call `$factory->clearSnapshots()` before reusing the same factory after deleting
+or recreating the backing read-model table.
+
 Example AWS CLI setup:
 
 ```bash

--- a/src/DynamoDbRepository.php
+++ b/src/DynamoDbRepository.php
@@ -23,17 +23,26 @@ final class DynamoDbRepository implements Repository
         private readonly JsonDecoder $jsonDecoder,
         private readonly string $table,
         private readonly string $name,
-        private readonly string $class
+        private readonly string $class,
+        private readonly ReadModelSnapshotStore $snapshots
     ) {
     }
 
     public function save(Identifiable $data): void
     {
-        $encodedData = $this->jsonEncoder->encode($this->serializer->serialize($data));
+        $id             = $data->getId();
+        $serializedData = $this->serializer->serialize($data);
+        $snapshot       = new ReadModelSnapshot($this->table, $this->name, $this->class, $id, $serializedData);
 
-        $putItemInput = $this->inputBuilder->buildPutItemInput($this->table, $this->name, $data->getId(), $encodedData);
+        if ($this->snapshots->hasSameSnapshot($snapshot)) {
+            return;
+        }
+
+        $encodedData  = $this->jsonEncoder->encode($serializedData);
+        $putItemInput = $this->inputBuilder->buildPutItemInput($this->table, $this->name, $id, $encodedData);
 
         $this->client->putItem($putItemInput)->resolve();
+        $this->snapshots->remember($snapshot);
     }
 
     public function find($id): ?Identifiable
@@ -52,7 +61,7 @@ final class DynamoDbRepository implements Repository
             throw new UnexpectedEncodedData('Data', 'string', $encodedData);
         }
 
-        return $this->deserializeReadModel($encodedData);
+        return $this->deserializeReadModel($encodedData, (string) $id);
     }
 
     /**
@@ -79,7 +88,13 @@ final class DynamoDbRepository implements Repository
                 throw new UnexpectedEncodedData('Data', 'string', $encodedData);
             }
 
-            $items[] = $this->deserializeReadModel($encodedData);
+            $observedId = $item['Id']->getS();
+
+            if (!is_string($observedId)) {
+                throw new UnexpectedEncodedData('Id', 'string', $observedId);
+            }
+
+            $items[] = $this->deserializeReadModel($encodedData, $observedId);
         }
 
         $items = array_filter($items, function (Identifiable $model) use ($fields): bool {
@@ -136,7 +151,13 @@ final class DynamoDbRepository implements Repository
                 throw new UnexpectedEncodedData('Data', 'string', $encodedData);
             }
 
-            $items[] = $this->deserializeReadModel($encodedData);
+            $observedId = $item['Id']->getS();
+
+            if (!is_string($observedId)) {
+                throw new UnexpectedEncodedData('Id', 'string', $observedId);
+            }
+
+            $items[] = $this->deserializeReadModel($encodedData, $observedId);
         }
 
         return $items;
@@ -145,9 +166,10 @@ final class DynamoDbRepository implements Repository
     public function remove($id): void
     {
         $this->client->deleteItem($this->inputBuilder->buildDeleteItemInput($this->table, $this->name, (string) $id))->resolve();
+        $this->snapshots->forget($this->table, $this->name, $this->class, (string) $id);
     }
 
-    private function deserializeReadModel(string $encodedData): Identifiable
+    private function deserializeReadModel(string $encodedData, string $observedId): Identifiable
     {
         $serializedData = $this->jsonDecoder->decode($encodedData);
 
@@ -163,6 +185,12 @@ final class DynamoDbRepository implements Repository
 
         if (!($data instanceof $this->class && $data instanceof Identifiable)) {
             throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
+        }
+
+        $id = $data->getId();
+
+        if ($id === $observedId) {
+            $this->snapshots->remember(new ReadModelSnapshot($this->table, $this->name, $this->class, $id, $serializedData));
         }
 
         return $data;

--- a/src/DynamoDbRepositoryFactory.php
+++ b/src/DynamoDbRepositoryFactory.php
@@ -14,12 +14,18 @@ final class DynamoDbRepositoryFactory implements RepositoryFactory
     public function __construct(
         private readonly DynamoDbClient $client,
         private readonly Serializer $serializer,
-        private readonly string $table
+        private readonly string $table,
+        private readonly ReadModelSnapshotStore $snapshots
     ) {
     }
 
     public function create(string $name, string $class): Repository
     {
-        return new DynamoDbRepository($this->client, new InputBuilder(), $this->serializer, new JsonEncoder(), new JsonDecoder(), $this->table, $name, $class);
+        return new DynamoDbRepository($this->client, new InputBuilder(), $this->serializer, new JsonEncoder(), new JsonDecoder(), $this->table, $name, $class, $this->snapshots);
+    }
+
+    public function clearSnapshots(): void
+    {
+        $this->snapshots->clear();
     }
 }

--- a/src/ReadModelSnapshot.php
+++ b/src/ReadModelSnapshot.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+final class ReadModelSnapshot
+{
+    /**
+     * @param array<mixed> $serializedData
+     */
+    public function __construct(
+        public readonly string $table,
+        public readonly string $name,
+        public readonly string $class,
+        public readonly string $id,
+        public readonly array $serializedData
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $serializedData
+     */
+    public function matches(array $serializedData): bool
+    {
+        return $this->serializedData === $serializedData;
+    }
+
+    public function key(): string
+    {
+        return self::keyFor($this->table, $this->name, $this->class, $this->id);
+    }
+
+    public static function keyFor(string $table, string $name, string $class, string $id): string
+    {
+        $key = json_encode([$table, $name, $class, $id], JSON_THROW_ON_ERROR);
+
+        if (!is_string($key)) {
+            throw new \JsonException('Snapshot key encoding did not produce a string.');
+        }
+
+        return $key;
+    }
+}

--- a/src/ReadModelSnapshotStore.php
+++ b/src/ReadModelSnapshotStore.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+final class ReadModelSnapshotStore
+{
+    /**
+     * @var array<string, ReadModelSnapshot>
+     */
+    private array $snapshots = [];
+
+    public function hasSameSnapshot(ReadModelSnapshot $snapshot): bool
+    {
+        $remembered = $this->snapshots[$snapshot->key()] ?? null;
+
+        return $remembered instanceof ReadModelSnapshot
+            && $remembered->matches($snapshot->serializedData);
+    }
+
+    public function remember(ReadModelSnapshot $snapshot): void
+    {
+        $this->snapshots[$snapshot->key()] = $snapshot;
+    }
+
+    public function forget(string $table, string $name, string $class, string $id): void
+    {
+        unset($this->snapshots[ReadModelSnapshot::keyFor($table, $name, $class, $id)]);
+    }
+
+    public function clear(): void
+    {
+        $this->snapshots = [];
+    }
+}

--- a/tests/DynamoDbRepositoryResponseResolutionTest.php
+++ b/tests/DynamoDbRepositoryResponseResolutionTest.php
@@ -15,6 +15,7 @@ use chrisjenkinson\DynamoDbReadModel\DynamoDbRepository;
 use chrisjenkinson\DynamoDbReadModel\InputBuilder;
 use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
 use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -59,7 +60,8 @@ final class DynamoDbRepositoryResponseResolutionTest extends TestCase
             new JsonDecoder(),
             'table',
             'name',
-            RepositoryTestReadModel::class
+            RepositoryTestReadModel::class,
+            new ReadModelSnapshotStore()
         );
     }
 

--- a/tests/DynamoDbRepositorySnapshotSuppressionTest.php
+++ b/tests/DynamoDbRepositorySnapshotSuppressionTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Result\DeleteItemOutput;
+use AsyncAws\DynamoDb\Result\GetItemOutput;
+use AsyncAws\DynamoDb\Result\PutItemOutput;
+use AsyncAws\DynamoDb\Result\QueryOutput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbRepositoryFactory;
+use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshot;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
+{
+    public function test_it_skips_the_physical_write_when_the_saved_model_matches_the_snapshot_loaded_by_find(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+        $client->expects($this->never())->method('putItem');
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        $model = $repository->find('id');
+        self::assertInstanceOf(RepositoryTestReadModel::class, $model);
+
+        $repository->save($model);
+    }
+
+    public function test_it_writes_when_the_saved_model_differs_from_the_snapshot_loaded_by_find(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        $model = $repository->find('id');
+        self::assertInstanceOf(RepositoryTestReadModel::class, $model);
+
+        $repository->save(new RepositoryTestReadModel('id', 'changed', 'foo', []));
+    }
+
+    public function test_it_writes_when_no_prior_snapshot_is_available(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('getItem');
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+    }
+
+    public function test_it_skips_the_second_physical_write_when_the_same_state_was_already_saved(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $model      = new RepositoryTestReadModel('id', 'name', 'foo', []);
+
+        $repository->save($model);
+        $repository->save($model);
+    }
+
+    public function test_it_does_not_snapshot_failed_saves(): void
+    {
+        $successfulOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->exactly(2))
+            ->method('putItem')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \RuntimeException('failed')),
+                $successfulOutput
+            );
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $model      = new RepositoryTestReadModel('id', 'name', 'foo', []);
+
+        try {
+            $repository->save($model);
+            self::fail('Expected the first save to fail.');
+        } catch (\Throwable) {
+        }
+
+        $repository->save($model);
+    }
+
+    public function test_it_clears_the_snapshot_when_a_model_is_removed(): void
+    {
+        $deleteItemOutput = new DeleteItemOutput($this->createResponse());
+        $putItemOutput    = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+        $client->expects($this->once())->method('deleteItem')->willReturn($deleteItemOutput);
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $model      = $repository->find('id');
+        self::assertInstanceOf(RepositoryTestReadModel::class, $model);
+
+        $repository->remove('id');
+        $repository->save($model);
+    }
+
+    public function test_it_writes_when_find_observes_a_row_whose_physical_id_does_not_match_the_payload_id(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', [])));
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $model      = $repository->find('physical-id');
+        self::assertInstanceOf(RepositoryTestReadModel::class, $model);
+
+        $repository->save($model);
+    }
+
+    public function test_it_shares_snapshots_across_repositories_created_by_the_same_factory(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+        $client->expects($this->never())->method('putItem');
+
+        $factory = $this->createFactory($client);
+
+        $model = $factory->create('items', RepositoryTestReadModel::class)->find('id');
+        self::assertInstanceOf(RepositoryTestReadModel::class, $model);
+
+        $factory->create('items', RepositoryTestReadModel::class)->save($model);
+    }
+
+    public function test_it_does_not_share_snapshots_between_repository_names(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $factory = $this->createFactory($client);
+
+        $model = $factory->create('items', RepositoryTestReadModel::class)->find('id');
+        self::assertInstanceOf(RepositoryTestReadModel::class, $model);
+
+        $factory->create('other_items', RepositoryTestReadModel::class)->save($model);
+    }
+
+    public function test_it_does_not_share_snapshots_between_classes(): void
+    {
+        $store = new ReadModelSnapshotStore();
+        $store->remember(new ReadModelSnapshot('table', 'items', RepositoryTestReadModel::class, 'id', [
+            'payload' => [
+                'id' => 'id',
+            ],
+        ]));
+
+        self::assertFalse($store->hasSameSnapshot(new ReadModelSnapshot('table', 'items', UnexpectedSerializableReadModel::class, 'id', [
+            'payload' => [
+                'id' => 'id',
+            ],
+        ])));
+    }
+
+    public function test_it_writes_after_factory_snapshots_are_cleared(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $factory    = $this->createFactory($client);
+        $repository = $factory->create('items', RepositoryTestReadModel::class);
+
+        $model = $repository->find('id');
+        self::assertInstanceOf(RepositoryTestReadModel::class, $model);
+
+        $factory->clearSnapshots();
+        $repository->save($model);
+    }
+
+    public function test_it_snapshots_models_loaded_by_find_all(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+        $client->expects($this->never())->method('putItem');
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        $models = $repository->findAll();
+        self::assertCount(1, $models);
+        self::assertContainsOnlyInstancesOf(RepositoryTestReadModel::class, $models);
+
+        $repository->save($models[0]);
+    }
+
+    public function test_it_snapshots_models_loaded_by_find_by(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+        $client->expects($this->never())->method('putItem');
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        $models = $repository->findBy([
+            'foo' => 'foo',
+        ]);
+        self::assertCount(1, $models);
+        self::assertContainsOnlyInstancesOf(RepositoryTestReadModel::class, $models);
+
+        $repository->save($models[0]);
+    }
+
+    public function test_it_snapshots_models_read_by_find_by_even_when_they_are_filtered_out(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('id', 'name', 'not-matching', [])));
+        $client->expects($this->never())->method('putItem');
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        self::assertSame([], $repository->findBy([
+            'foo' => 'matching',
+        ]));
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'not-matching', []));
+    }
+
+    public function test_it_does_not_snapshot_models_loaded_by_query_when_the_physical_id_differs_from_the_payload_id(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', []), 'physical-id'));
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        $models = $repository->findAll();
+        self::assertCount(1, $models);
+        self::assertContainsOnlyInstancesOf(RepositoryTestReadModel::class, $models);
+
+        $repository->save($models[0]);
+    }
+
+    private function createFactory(DynamoDbClient $client): DynamoDbRepositoryFactory
+    {
+        return new DynamoDbRepositoryFactory($client, new SimpleInterfaceSerializer(), 'table', new ReadModelSnapshotStore());
+    }
+
+    private function getItemOutputFor(RepositoryTestReadModel $model): GetItemOutput
+    {
+        $output = $this->createStub(GetItemOutput::class);
+        $output->method('getItem')->willReturn([
+            'Data' => new AttributeValue([
+                'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+            ]),
+        ]);
+
+        return $output;
+    }
+
+    private function queryOutputFor(RepositoryTestReadModel $model, ?string $physicalId = null): QueryOutput
+    {
+        $physicalId ??= $model->getId();
+
+        $output = $this->createStub(QueryOutput::class);
+        $output->method('getCount')->willReturn(1);
+        $output->method('getItems')->willReturn([
+            [
+                'Id' => new AttributeValue([
+                    'S' => $physicalId,
+                ]),
+                'Data' => new AttributeValue([
+                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                ]),
+            ],
+        ]);
+
+        return $output;
+    }
+
+    private function createResponse(): Response
+    {
+        $client = new MockHttpClient(new SimpleMockedResponse('{}'));
+
+        return new Response($client->request('POST', 'http://localhost'), $client, new NullLogger());
+    }
+}

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -18,6 +18,7 @@ use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
 use chrisjenkinson\DynamoDbReadModel\InputBuilder;
 use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
 use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
 
 final class DynamoDbRepositoryTest extends RepositoryTestCase
 {
@@ -31,7 +32,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
 
         $tableManager = new DynamoDbTableManager($client, new InputBuilder(), self::TABLE_NAME);
         $serializer   = new SimpleInterfaceSerializer();
-        $factory      = new DynamoDbRepositoryFactory($client, $serializer, self::TABLE_NAME);
+        $factory      = new DynamoDbRepositoryFactory($client, $serializer, self::TABLE_NAME, new ReadModelSnapshotStore());
 
         $tableManager->deleteTable();
         $tableManager->createTable();
@@ -171,7 +172,8 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
             new JsonDecoder(),
             self::TABLE_NAME,
             'non-identifiable',
-            NonIdentifiableSerializableReadModel::class
+            NonIdentifiableSerializableReadModel::class,
+            new ReadModelSnapshotStore()
         );
 
         $this->expectException(UnexpectedReadModel::class);

--- a/tests/ReadModelSnapshotTest.php
+++ b/tests/ReadModelSnapshotTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshot;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
+use PHPUnit\Framework\TestCase;
+
+final class ReadModelSnapshotTest extends TestCase
+{
+    public function test_key_matches_key_for(): void
+    {
+        $snapshot = new ReadModelSnapshot('table', 'items', RepositoryTestReadModel::class, 'id', [
+            'payload' => [
+                'id' => 'id',
+            ],
+        ]);
+
+        self::assertSame(
+            ReadModelSnapshot::keyFor('table', 'items', RepositoryTestReadModel::class, 'id'),
+            $snapshot->key()
+        );
+    }
+
+    public function test_key_encoding_is_unambiguous_for_delimiter_like_ids(): void
+    {
+        self::assertNotSame(
+            ReadModelSnapshot::keyFor('table', 'items', RepositoryTestReadModel::class, "a\0b"),
+            ReadModelSnapshot::keyFor("table\0items", RepositoryTestReadModel::class, 'a', 'b')
+        );
+    }
+
+    public function test_matches_exact_serialized_state(): void
+    {
+        $snapshot = new ReadModelSnapshot('table', 'items', RepositoryTestReadModel::class, 'id', [
+            'payload' => [
+                'id'   => 'id',
+                'name' => 'name',
+            ],
+        ]);
+
+        self::assertTrue($snapshot->matches([
+            'payload' => [
+                'id'   => 'id',
+                'name' => 'name',
+            ],
+        ]));
+        self::assertFalse($snapshot->matches([
+            'payload' => [
+                'name' => 'name',
+                'id'   => 'id',
+            ],
+        ]));
+    }
+
+    public function test_store_isolates_snapshots_by_table_repository_name_and_class(): void
+    {
+        $store = new ReadModelSnapshotStore();
+        $store->remember(new ReadModelSnapshot('table', 'items', RepositoryTestReadModel::class, 'id', [
+            'payload' => [
+                'id' => 'id',
+            ],
+        ]));
+
+        self::assertFalse($store->hasSameSnapshot(new ReadModelSnapshot('other-table', 'items', RepositoryTestReadModel::class, 'id', [
+            'payload' => [
+                'id' => 'id',
+            ],
+        ])));
+        self::assertFalse($store->hasSameSnapshot(new ReadModelSnapshot('table', 'other-items', RepositoryTestReadModel::class, 'id', [
+            'payload' => [
+                'id' => 'id',
+            ],
+        ])));
+        self::assertFalse($store->hasSameSnapshot(new ReadModelSnapshot('table', 'items', UnexpectedSerializableReadModel::class, 'id', [
+            'payload' => [
+                'id' => 'id',
+            ],
+        ])));
+    }
+}


### PR DESCRIPTION
Adds process-local read model snapshots so repository saves can skip physical DynamoDB writes when the serialized read model state has not changed.

- injects a shared snapshot store into the factory/repositories
- records snapshots from reads and successful writes
- preserves normal writes when no matching snapshot exists
- documents the constructor change