### PR TITLE
Add deferred DynamoDB read-model repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,14 @@ extra DynamoDB read:
 $factory = new DynamoDbRepositoryFactory($client, $serializer, 'read-models', new ReadModelSnapshotStore());
 ```
 
-Direct `DynamoDbRepository` construction takes explicit storage and matcher
-collaborators. Prefer the factory unless you need manual wiring:
+The factory is the recommended construction path. It creates the per-repository
+storage and matcher internally.
+
+Direct `DynamoDbRepository` construction is still possible, but its constructor
+now expects explicit storage and matcher collaborators. If you manually construct
+repositories, move the DynamoDB-specific arguments into a
+`DynamoDbReadModelStorage` configured for that table, repository name, and read
+model class, then pass that storage with a `ReadModelFieldMatcher`:
 
 ```php
 $storage = new DynamoDbReadModelStorage(
@@ -96,6 +102,11 @@ $repository->save($model);
 // Write pending removals and saves to DynamoDB.
 $repository->flush();
 ```
+
+`createDeferred()` is package-specific and is not part of Broadway's
+`RepositoryFactory` interface. Code that needs deferred repository creation
+should type-hint `DeferredRepositoryFactory` or the concrete
+`DynamoDbRepositoryFactory`.
 
 A deferred repository still implements `Broadway\ReadModel\Repository`, and also
 implements `FlushableRepository`:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The library queries by `Name` to load all read models for a repository, and uses
 `Name` + `Id` for single-item reads, writes, and deletes. It does not require
 secondary indexes.
 
+The DynamoDB `Id` value is required to match the serialized read model's
+`Identifiable::getId()`. Rows where the physical key and payload id differ are
+treated as invalid stored data and rejected on read; repair those rows with
+explicit operational tooling rather than relying on repository normalization.
+
 `find($id)` uses the full primary key (`Name` + `Id`) and is the bounded lookup
 to prefer for production read paths. `findAll()` queries the full repository
 partition for the configured `Name` and returns every read model in memory.
@@ -46,10 +51,11 @@ extra DynamoDB read:
 $factory = new DynamoDbRepositoryFactory($client, $serializer, 'read-models', new ReadModelSnapshotStore());
 ```
 
-Direct `DynamoDbRepository` construction also needs the same dependency:
+Direct `DynamoDbRepository` construction takes explicit storage and matcher
+collaborators. Prefer the factory unless you need manual wiring:
 
 ```php
-$repository = new DynamoDbRepository(
+$storage = new DynamoDbReadModelStorage(
     $client,
     $inputBuilder,
     $serializer,
@@ -60,10 +66,104 @@ $repository = new DynamoDbRepository(
     MyReadModel::class,
     new ReadModelSnapshotStore()
 );
+
+$repository = new DynamoDbRepository(
+    $storage,
+    new ReadModelFieldMatcher()
+);
 ```
 
 Call `$factory->clearSnapshots()` before reusing the same factory after deleting
 or recreating the backing read-model table.
+
+## Deferred Persistence
+
+Repositories created with `DynamoDbRepositoryFactory::create()` keep the original
+immediate behaviour: `save()` writes with `PutItem`, `remove()` writes with
+`DeleteItem`, and `find()` reads with `GetItem`.
+
+For replay or other batching-sensitive workflows, opt in explicitly to deferred
+persistence:
+
+```php
+$repository = $factory->createDeferred('repository-name', MyReadModel::class);
+
+$model = $repository->find($id) ?? new MyReadModel($id);
+
+// Projector handlers can keep using Broadway\Repository methods.
+$repository->save($model);
+
+// Write pending removals and saves to DynamoDB.
+$repository->flush();
+```
+
+A deferred repository still implements `Broadway\ReadModel\Repository`, and also
+implements `FlushableRepository`:
+
+```php
+interface FlushableRepository extends Broadway\ReadModel\Repository
+{
+    public function flush(): void;
+
+    public function flushWithContext(array $context): void;
+
+    public function clear(): void;
+
+    public function pendingOperations(): array;
+}
+```
+
+In deferred mode, `find($id)` checks an in-memory identity map before DynamoDB.
+`save()` captures the read model's serialized state at the time `save()` is
+called and stages that state in memory. Repeated saves for the same read-model id
+replace the staged state and collapse to one `PutItem` on `flush()`. Mutating a
+read model after `save()` does not change the staged write unless `save()` is
+called again. `remove()` marks the id removed in memory, so `find($id)` returns
+`null` until the item is saved again or `clear()` discards the deferred state.
+Saving a removed id cancels the pending delete.
+
+`pendingOperations()` returns the currently staged removes and save-time
+snapshots for inspection. `flush()` writes pending deletes and saves one item at
+a time through the same DynamoDB storage path as the immediate repository. If a
+write fails, the failing and remaining pending state is retained for retry or
+inspection. Successfully flushed entries are no longer pending. `clear()` only
+discards local managed, dirty, and removed state; it does not write anything.
+
+Failures are reported with `DeferredFlushFailed`, which includes the operation,
+read-model id, table, repository name, read-model class, and previous exception.
+The repository does not know application-level details such as tenant id,
+projector name, or source event id. Pass those at the flush boundary when they
+are useful:
+
+```php
+$repository->flushWithContext([
+    'tenantId' => $tenantId,
+    'projector' => SomeProjector::class,
+    'sourceEventId' => $eventId,
+]);
+```
+
+`findAll()` and `findBy()` are merge-aware: they query DynamoDB and overlay
+pending local saves/removes before returning results. They still perform a
+DynamoDB query each time, and DynamoDB reads use the repository's normal
+consistency settings. Deferred mode makes this repository's staged changes
+visible; it does not make broad projection queries transactional or globally
+fresh.
+
+`findBy()` remains available for Broadway compatibility and small read-side
+collections. Do not use it as a write-side invariant or duplicate guard during
+command handling, seeding, or projection rebuilds. Model those cases as
+deterministic lookup read models and query them with `find($id)`.
+
+The identity map is scoped to the deferred repository instance. It can return a
+cached model even if another process changes DynamoDB while the deferred
+repository is still open. Keep deferred repositories short-lived around a replay,
+seed, or console unit of work, and call `clear()` before reusing one across
+independent work. For long replays or seeds, use explicit `flush(); clear();`
+checkpoints when managed objects are no longer needed.
+
+This is a batching and performance boundary, not a DynamoDB transaction. A failed
+flush can leave earlier operations persisted and later operations still pending.
 
 Example AWS CLI setup:
 

--- a/src/DeferredDynamoDbRepository.php
+++ b/src/DeferredDynamoDbRepository.php
@@ -25,10 +25,7 @@ final class DeferredDynamoDbRepository implements FlushableRepository
 
     public function __construct(
         private readonly DynamoDbReadModelStorage $storage,
-        private readonly ReadModelFieldMatcher $matcher,
-        private readonly ?string $table = null,
-        private readonly ?string $name = null,
-        private readonly ?string $class = null
+        private readonly ReadModelFieldMatcher $matcher
     ) {
     }
 
@@ -134,7 +131,7 @@ final class DeferredDynamoDbRepository implements FlushableRepository
             try {
                 $this->storage->remove($id);
             } catch (\Throwable $exception) {
-                throw new DeferredFlushFailed(DeferredOperation::REMOVE, $id, $this->table, $this->name, $this->class, $context, $exception);
+                throw new DeferredFlushFailed(DeferredOperation::REMOVE, $id, $this->storage->table(), $this->storage->name(), $this->storage->readModelClass(), $context, $exception);
             }
 
             unset($this->removed[$index]);
@@ -144,7 +141,7 @@ final class DeferredDynamoDbRepository implements FlushableRepository
             try {
                 $this->storage->save($save);
             } catch (\Throwable $exception) {
-                throw new DeferredFlushFailed(DeferredOperation::SAVE, $id, $this->table, $this->name, $this->class, $context, $exception);
+                throw new DeferredFlushFailed(DeferredOperation::SAVE, $id, $this->storage->table(), $this->storage->name(), $this->storage->readModelClass(), $context, $exception);
             }
 
             unset($this->dirty[$id]);

--- a/src/DeferredDynamoDbRepository.php
+++ b/src/DeferredDynamoDbRepository.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+use Broadway\ReadModel\Identifiable;
+
+final class DeferredDynamoDbRepository implements FlushableRepository
+{
+    /**
+     * @var array<string, Identifiable>
+     */
+    private array $managed = [];
+
+    /**
+     * @var array<string, PreparedReadModelSave>
+     */
+    private array $dirty = [];
+
+    /**
+     * @var string[]
+     */
+    private array $removed = [];
+
+    public function __construct(
+        private readonly DynamoDbReadModelStorage $storage,
+        private readonly ReadModelFieldMatcher $matcher,
+        private readonly ?string $table = null,
+        private readonly ?string $name = null,
+        private readonly ?string $class = null
+    ) {
+    }
+
+    public function save(Identifiable $data): void
+    {
+        $id = $data->getId();
+
+        $this->dirty[$id] = $this->storage->prepareSave($data);
+        unset($this->managed[$id]);
+
+        $this->removed = array_diff($this->removed, [$id]);
+    }
+
+    public function find($id): ?Identifiable
+    {
+        $id = (string) $id;
+
+        if (in_array($id, $this->removed, true)) {
+            return null;
+        }
+
+        if (isset($this->managed[$id])) {
+            return $this->managed[$id];
+        }
+
+        if (isset($this->dirty[$id])) {
+            $this->managed[$id] = $this->storage->modelFromPreparedSave($this->dirty[$id]);
+
+            return $this->managed[$id];
+        }
+
+        $model = $this->storage->find($id);
+
+        if ($model instanceof Identifiable) {
+            $this->managed[$id] = $model;
+        }
+
+        return $model;
+    }
+
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function findBy(array $fields): array
+    {
+        if ([] === $fields) {
+            return [];
+        }
+
+        return array_values(array_filter(
+            $this->findAll(),
+            fn (Identifiable $model): bool => $this->matcher->matches($model, $fields)
+        ));
+    }
+
+    public function findAll(): array
+    {
+        $models = [];
+
+        foreach ($this->storage->findAll() as $model) {
+            $id = $model->getId();
+
+            if (in_array($id, $this->removed, true)) {
+                continue;
+            }
+
+            $this->managed[$id] = $this->managed[$id] ?? $model;
+            $models[$id]        = $this->managed[$id];
+        }
+
+        foreach ($this->dirty as $id => $save) {
+            if (!in_array($id, $this->removed, true)) {
+                $this->managed[$id] = $this->storage->modelFromPreparedSave($save);
+                $models[$id]        = $this->managed[$id];
+            }
+        }
+
+        return array_values($models);
+    }
+
+    public function remove($id): void
+    {
+        $id = (string) $id;
+
+        unset($this->managed[$id], $this->dirty[$id]);
+
+        if (!in_array($id, $this->removed, true)) {
+            $this->removed[] = $id;
+        }
+    }
+
+    public function flush(): void
+    {
+        $this->flushWithContext([]);
+    }
+
+    /**
+     * @param array<string, scalar|null> $context
+     */
+    public function flushWithContext(array $context): void
+    {
+        foreach ($this->removed as $index => $id) {
+            try {
+                $this->storage->remove($id);
+            } catch (\Throwable $exception) {
+                throw new DeferredFlushFailed(DeferredOperation::REMOVE, $id, $this->table, $this->name, $this->class, $context, $exception);
+            }
+
+            unset($this->removed[$index]);
+        }
+
+        foreach ($this->dirty as $id => $save) {
+            try {
+                $this->storage->save($save);
+            } catch (\Throwable $exception) {
+                throw new DeferredFlushFailed(DeferredOperation::SAVE, $id, $this->table, $this->name, $this->class, $context, $exception);
+            }
+
+            unset($this->dirty[$id]);
+        }
+    }
+
+    public function clear(): void
+    {
+        $this->managed = [];
+        $this->dirty   = [];
+        $this->removed = [];
+    }
+
+    public function pendingOperations(): array
+    {
+        $operations = [];
+
+        foreach ($this->removed as $id) {
+            $operations[] = new DeferredOperation(DeferredOperation::REMOVE, $id);
+        }
+
+        foreach ($this->dirty as $id => $save) {
+            $operations[] = new DeferredOperation(DeferredOperation::SAVE, $id, $this->storage->modelFromPreparedSave($save));
+        }
+
+        return $operations;
+    }
+}

--- a/src/DeferredDynamoDbRepository.php
+++ b/src/DeferredDynamoDbRepository.php
@@ -83,7 +83,8 @@ final class DeferredDynamoDbRepository implements FlushableRepository
 
     public function findAll(): array
     {
-        $models = [];
+        $models        = [];
+        $managedBefore = array_fill_keys(array_keys($this->managed), true);
 
         foreach ($this->storage->findAll() as $model) {
             $id = $model->getId();
@@ -98,8 +99,11 @@ final class DeferredDynamoDbRepository implements FlushableRepository
 
         foreach ($this->dirty as $id => $save) {
             if (!in_array($id, $this->removed, true)) {
-                $this->managed[$id] = $this->storage->modelFromPreparedSave($save);
-                $models[$id]        = $this->managed[$id];
+                if (!isset($managedBefore[$id])) {
+                    $this->managed[$id] = $this->storage->modelFromPreparedSave($save);
+                }
+
+                $models[$id] = $this->managed[$id];
             }
         }
 

--- a/src/DeferredFlushFailed.php
+++ b/src/DeferredFlushFailed.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+final class DeferredFlushFailed extends \RuntimeException
+{
+    /**
+     * @param array<string, scalar|null> $context
+     */
+    public function __construct(
+        public readonly string $operation,
+        public readonly string $id,
+        public readonly ?string $table,
+        public readonly ?string $repositoryName,
+        public readonly ?string $readModelClass,
+        public readonly array $context,
+        \Throwable $previous
+    ) {
+        parent::__construct(sprintf(
+            'Deferred read-model flush failed while performing %s for id "%s".',
+            $operation,
+            $id
+        ), 0, $previous);
+    }
+}

--- a/src/DeferredOperation.php
+++ b/src/DeferredOperation.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+use Broadway\ReadModel\Identifiable;
+
+final class DeferredOperation
+{
+    public const REMOVE = 'remove';
+
+    public const SAVE = 'save';
+
+    public function __construct(
+        public readonly string $operation,
+        public readonly string $id,
+        public readonly ?Identifiable $model = null
+    ) {
+    }
+}

--- a/src/DeferredRepositoryFactory.php
+++ b/src/DeferredRepositoryFactory.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+interface DeferredRepositoryFactory
+{
+    public function createDeferred(string $name, string $class): FlushableRepository;
+}

--- a/src/DynamoDbReadModelStorage.php
+++ b/src/DynamoDbReadModelStorage.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+use AsyncAws\DynamoDb\DynamoDbClient;
+use Broadway\ReadModel\Identifiable;
+use Broadway\Serializer\Serializer;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedEncodedData;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
+
+final class DynamoDbReadModelStorage
+{
+    public function __construct(
+        private readonly DynamoDbClient $client,
+        private readonly InputBuilder $inputBuilder,
+        private readonly Serializer $serializer,
+        private readonly JsonEncoder $jsonEncoder,
+        private readonly JsonDecoder $jsonDecoder,
+        private readonly string $table,
+        private readonly string $name,
+        private readonly string $class,
+        private readonly ReadModelSnapshotStore $snapshots
+    ) {
+    }
+
+    public function prepareSave(Identifiable $data): PreparedReadModelSave
+    {
+        return new PreparedReadModelSave($data->getId(), $this->serializer->serialize($data));
+    }
+
+    public function save(PreparedReadModelSave $save): void
+    {
+        $snapshot = new ReadModelSnapshot($this->table, $this->name, $this->class, $save->id, $save->serializedData);
+
+        if ($this->snapshots->hasSameSnapshot($snapshot)) {
+            return;
+        }
+
+        $encodedData  = $this->jsonEncoder->encode($save->serializedData);
+        $putItemInput = $this->inputBuilder->buildPutItemInput($this->table, $this->name, $save->id, $encodedData);
+
+        $this->client->putItem($putItemInput)->resolve();
+        $this->snapshots->remember($snapshot);
+    }
+
+    public function find(string $id): ?Identifiable
+    {
+        $result = $this->client->getItem($this->inputBuilder->buildGetItemInput($this->table, $this->name, $id));
+
+        $item = $result->getItem();
+
+        if ([] === $item) {
+            return null;
+        }
+
+        $encodedData = $item['Data']->getS();
+
+        if (!is_string($encodedData)) {
+            throw new UnexpectedEncodedData('Data', 'string', $encodedData);
+        }
+
+        return $this->deserializeReadModel($encodedData, $id);
+    }
+
+    /**
+     * @return Identifiable[]
+     */
+    public function findAll(): array
+    {
+        $result = $this->client->query($this->inputBuilder->buildQueryInput($this->table, $this->name));
+
+        if (0 === $result->getCount()) {
+            return [];
+        }
+
+        $models = [];
+
+        foreach ($result->getItems() as $item) {
+            $encodedData = $item['Data']->getS();
+
+            if (!is_string($encodedData)) {
+                throw new UnexpectedEncodedData('Data', 'string', $encodedData);
+            }
+
+            $observedId = $item['Id']->getS();
+
+            if (!is_string($observedId)) {
+                throw new UnexpectedEncodedData('Id', 'string', $observedId);
+            }
+
+            $models[] = $this->deserializeReadModel($encodedData, $observedId);
+        }
+
+        return $models;
+    }
+
+    public function remove(string $id): void
+    {
+        $this->client->deleteItem($this->inputBuilder->buildDeleteItemInput($this->table, $this->name, $id))->resolve();
+        $this->snapshots->forget($this->table, $this->name, $this->class, $id);
+    }
+
+    public function modelFromPreparedSave(PreparedReadModelSave $save): Identifiable
+    {
+        return $this->deserializeSerializedReadModel($save->serializedData, $save->id, false);
+    }
+
+    private function deserializeReadModel(string $encodedData, string $observedId): Identifiable
+    {
+        return $this->deserializeSerializedReadModel($this->jsonDecoder->decode($encodedData), $observedId, true);
+    }
+
+    /**
+     * @param array<string, mixed> $serializedData
+     */
+    private function deserializeSerializedReadModel(array $serializedData, string $observedId, bool $rememberSnapshot): Identifiable
+    {
+        if (!isset($serializedData['class']) || !is_string($serializedData['class'])) {
+            throw new UnexpectedReadModel(actual: get_debug_type($serializedData['class'] ?? null), expected: $this->class);
+        }
+
+        if ($serializedData['class'] !== $this->class) {
+            throw new UnexpectedReadModel(actual: $serializedData['class'], expected: $this->class);
+        }
+
+        $data = $this->serializer->deserialize($serializedData);
+
+        if (!($data instanceof $this->class && $data instanceof Identifiable)) {
+            throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
+        }
+
+        $id = $data->getId();
+
+        if ($id !== $observedId) {
+            throw new UnexpectedReadModel(actual: sprintf('%s with id %s', $data::class, $id), expected: sprintf('%s with id %s', $this->class, $observedId));
+        }
+
+        if ($rememberSnapshot) {
+            $this->snapshots->remember(new ReadModelSnapshot($this->table, $this->name, $this->class, $id, $serializedData));
+        }
+
+        return $data;
+    }
+}

--- a/src/DynamoDbReadModelStorage.php
+++ b/src/DynamoDbReadModelStorage.php
@@ -25,6 +25,21 @@ final class DynamoDbReadModelStorage
     ) {
     }
 
+    public function table(): string
+    {
+        return $this->table;
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function readModelClass(): string
+    {
+        return $this->class;
+    }
+
     public function prepareSave(Identifiable $data): PreparedReadModelSave
     {
         return new PreparedReadModelSave($data->getId(), $this->serializer->serialize($data));

--- a/src/DynamoDbReadModelStorage.php
+++ b/src/DynamoDbReadModelStorage.php
@@ -42,6 +42,10 @@ final class DynamoDbReadModelStorage
 
     public function prepareSave(Identifiable $data): PreparedReadModelSave
     {
+        if (!($data instanceof $this->class)) {
+            throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
+        }
+
         return new PreparedReadModelSave($data->getId(), $this->serializer->serialize($data));
     }
 

--- a/src/DynamoDbRepository.php
+++ b/src/DynamoDbRepository.php
@@ -4,64 +4,25 @@ declare(strict_types=1);
 
 namespace chrisjenkinson\DynamoDbReadModel;
 
-use AsyncAws\DynamoDb\DynamoDbClient;
 use Broadway\ReadModel\Identifiable;
 use Broadway\ReadModel\Repository;
-use Broadway\Serializer\Serializer;
-use chrisjenkinson\DynamoDbReadModel\Exception\CannotFilterWithNonexistentKey;
-use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedEncodedData;
-use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
-use ReflectionClass;
 
 final class DynamoDbRepository implements Repository
 {
     public function __construct(
-        private readonly DynamoDbClient $client,
-        private readonly InputBuilder $inputBuilder,
-        private readonly Serializer $serializer,
-        private readonly JsonEncoder $jsonEncoder,
-        private readonly JsonDecoder $jsonDecoder,
-        private readonly string $table,
-        private readonly string $name,
-        private readonly string $class,
-        private readonly ReadModelSnapshotStore $snapshots
+        private readonly DynamoDbReadModelStorage $storage,
+        private readonly ReadModelFieldMatcher $matcher
     ) {
     }
 
     public function save(Identifiable $data): void
     {
-        $id             = $data->getId();
-        $serializedData = $this->serializer->serialize($data);
-        $snapshot       = new ReadModelSnapshot($this->table, $this->name, $this->class, $id, $serializedData);
-
-        if ($this->snapshots->hasSameSnapshot($snapshot)) {
-            return;
-        }
-
-        $encodedData  = $this->jsonEncoder->encode($serializedData);
-        $putItemInput = $this->inputBuilder->buildPutItemInput($this->table, $this->name, $id, $encodedData);
-
-        $this->client->putItem($putItemInput)->resolve();
-        $this->snapshots->remember($snapshot);
+        $this->storage->save($this->storage->prepareSave($data));
     }
 
     public function find($id): ?Identifiable
     {
-        $result = $this->client->getItem($this->inputBuilder->buildGetItemInput($this->table, $this->name, (string) $id));
-
-        $item = $result->getItem();
-
-        if ([] === $item) {
-            return null;
-        }
-
-        $encodedData = $item['Data']->getS();
-
-        if (!is_string($encodedData)) {
-            throw new UnexpectedEncodedData('Data', 'string', $encodedData);
-        }
-
-        return $this->deserializeReadModel($encodedData, (string) $id);
+        return $this->storage->find((string) $id);
     }
 
     /**
@@ -73,126 +34,21 @@ final class DynamoDbRepository implements Repository
             return [];
         }
 
-        $result = $this->client->query($this->inputBuilder->buildQueryInput($this->table, $this->name));
-
-        if (0 === $result->getCount()) {
-            return [];
-        }
-
-        $items = [];
-
-        foreach ($result->getItems() as $item) {
-            $encodedData = $item['Data']->getS();
-
-            if (!is_string($encodedData)) {
-                throw new UnexpectedEncodedData('Data', 'string', $encodedData);
-            }
-
-            $observedId = $item['Id']->getS();
-
-            if (!is_string($observedId)) {
-                throw new UnexpectedEncodedData('Id', 'string', $observedId);
-            }
-
-            $items[] = $this->deserializeReadModel($encodedData, $observedId);
-        }
-
-        $items = array_filter($items, function (Identifiable $model) use ($fields): bool {
-            $reflectedClass = new ReflectionClass($model);
-
-            foreach ($fields as $field => $value) {
-                $methodName = sprintf('get%s', ucfirst($field));
-
-                if ($reflectedClass->hasMethod($methodName)) {
-                    $method = $reflectedClass->getMethod($methodName);
-                    if (!$method->isPublic()) {
-                        throw new CannotFilterWithNonexistentKey(model: $model::class, key: $field);
-                    }
-                    $modelValue = $method->invoke($model);
-                } elseif ($reflectedClass->hasProperty($field)) {
-                    $property = $reflectedClass->getProperty($field);
-                    if (!$property->isPublic()) {
-                        throw new CannotFilterWithNonexistentKey(model: $model::class, key: $field);
-                    }
-                    $modelValue = $property->getValue($model);
-                } else {
-                    throw new CannotFilterWithNonexistentKey(model: $model::class, key: $field);
-                }
-
-                if (is_array($modelValue) && !in_array($value, $modelValue, true)) {
-                    return false;
-                }
-
-                if (!is_array($modelValue) && $modelValue !== $value) {
-                    return false;
-                }
-            }
-
-            return true;
-        });
+        $items = array_filter(
+            $this->findAll(),
+            fn (Identifiable $model): bool => $this->matcher->matches($model, $fields)
+        );
 
         return array_values($items);
     }
 
     public function findAll(): array
     {
-        $result = $this->client->query($this->inputBuilder->buildQueryInput($this->table, $this->name));
-
-        if (0 === $result->getCount()) {
-            return [];
-        }
-
-        $items = [];
-
-        foreach ($result->getItems() as $item) {
-            $encodedData = $item['Data']->getS();
-
-            if (!is_string($encodedData)) {
-                throw new UnexpectedEncodedData('Data', 'string', $encodedData);
-            }
-
-            $observedId = $item['Id']->getS();
-
-            if (!is_string($observedId)) {
-                throw new UnexpectedEncodedData('Id', 'string', $observedId);
-            }
-
-            $items[] = $this->deserializeReadModel($encodedData, $observedId);
-        }
-
-        return $items;
+        return $this->storage->findAll();
     }
 
     public function remove($id): void
     {
-        $this->client->deleteItem($this->inputBuilder->buildDeleteItemInput($this->table, $this->name, (string) $id))->resolve();
-        $this->snapshots->forget($this->table, $this->name, $this->class, (string) $id);
-    }
-
-    private function deserializeReadModel(string $encodedData, string $observedId): Identifiable
-    {
-        $serializedData = $this->jsonDecoder->decode($encodedData);
-
-        if (!isset($serializedData['class']) || !is_string($serializedData['class'])) {
-            throw new UnexpectedReadModel(actual: get_debug_type($serializedData['class'] ?? null), expected: $this->class);
-        }
-
-        if ($serializedData['class'] !== $this->class) {
-            throw new UnexpectedReadModel(actual: $serializedData['class'], expected: $this->class);
-        }
-
-        $data = $this->serializer->deserialize($serializedData);
-
-        if (!($data instanceof $this->class && $data instanceof Identifiable)) {
-            throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
-        }
-
-        $id = $data->getId();
-
-        if ($id === $observedId) {
-            $this->snapshots->remember(new ReadModelSnapshot($this->table, $this->name, $this->class, $id, $serializedData));
-        }
-
-        return $data;
+        $this->storage->remove((string) $id);
     }
 }

--- a/src/DynamoDbRepositoryFactory.php
+++ b/src/DynamoDbRepositoryFactory.php
@@ -21,11 +21,31 @@ final class DynamoDbRepositoryFactory implements RepositoryFactory
 
     public function create(string $name, string $class): Repository
     {
-        return new DynamoDbRepository($this->client, new InputBuilder(), $this->serializer, new JsonEncoder(), new JsonDecoder(), $this->table, $name, $class, $this->snapshots);
+        return new DynamoDbRepository($this->createStorage($name, $class), new ReadModelFieldMatcher());
+    }
+
+    public function createDeferred(string $name, string $class): FlushableRepository
+    {
+        return new DeferredDynamoDbRepository($this->createStorage($name, $class), new ReadModelFieldMatcher(), $this->table, $name, $class);
     }
 
     public function clearSnapshots(): void
     {
         $this->snapshots->clear();
+    }
+
+    private function createStorage(string $name, string $class): DynamoDbReadModelStorage
+    {
+        return new DynamoDbReadModelStorage(
+            $this->client,
+            new InputBuilder(),
+            $this->serializer,
+            new JsonEncoder(),
+            new JsonDecoder(),
+            $this->table,
+            $name,
+            $class,
+            $this->snapshots
+        );
     }
 }

--- a/src/DynamoDbRepositoryFactory.php
+++ b/src/DynamoDbRepositoryFactory.php
@@ -9,7 +9,7 @@ use Broadway\ReadModel\Repository;
 use Broadway\ReadModel\RepositoryFactory;
 use Broadway\Serializer\Serializer;
 
-final class DynamoDbRepositoryFactory implements RepositoryFactory
+final class DynamoDbRepositoryFactory implements RepositoryFactory, DeferredRepositoryFactory
 {
     public function __construct(
         private readonly DynamoDbClient $client,

--- a/src/DynamoDbRepositoryFactory.php
+++ b/src/DynamoDbRepositoryFactory.php
@@ -26,7 +26,7 @@ final class DynamoDbRepositoryFactory implements RepositoryFactory
 
     public function createDeferred(string $name, string $class): FlushableRepository
     {
-        return new DeferredDynamoDbRepository($this->createStorage($name, $class), new ReadModelFieldMatcher(), $this->table, $name, $class);
+        return new DeferredDynamoDbRepository($this->createStorage($name, $class), new ReadModelFieldMatcher());
     }
 
     public function clearSnapshots(): void

--- a/src/FlushableRepository.php
+++ b/src/FlushableRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+use Broadway\ReadModel\Repository;
+
+interface FlushableRepository extends Repository
+{
+    /**
+     * Flushes pending changes one write at a time. This is not atomic and may
+     * leave earlier writes persisted if a later write fails.
+     */
+    public function flush(): void;
+
+    /**
+     * @param array<string, scalar|null> $context
+     */
+    public function flushWithContext(array $context): void;
+
+    public function clear(): void;
+
+    /**
+     * @return DeferredOperation[]
+     */
+    public function pendingOperations(): array;
+}

--- a/src/PreparedReadModelSave.php
+++ b/src/PreparedReadModelSave.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+final class PreparedReadModelSave
+{
+    /**
+     * @param array<string, mixed> $serializedData
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly array $serializedData
+    ) {
+    }
+}

--- a/src/ReadModelFieldMatcher.php
+++ b/src/ReadModelFieldMatcher.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+use Broadway\ReadModel\Identifiable;
+use chrisjenkinson\DynamoDbReadModel\Exception\CannotFilterWithNonexistentKey;
+use ReflectionClass;
+
+final class ReadModelFieldMatcher
+{
+    /**
+     * @param array<string, mixed> $fields
+     */
+    public function matches(Identifiable $model, array $fields): bool
+    {
+        $reflectedClass = new ReflectionClass($model);
+
+        foreach ($fields as $field => $value) {
+            $methodName = sprintf('get%s', ucfirst($field));
+
+            if ($reflectedClass->hasMethod($methodName)) {
+                $method = $reflectedClass->getMethod($methodName);
+                if (!$method->isPublic()) {
+                    throw new CannotFilterWithNonexistentKey(model: $model::class, key: $field);
+                }
+                $modelValue = $method->invoke($model);
+            } elseif ($reflectedClass->hasProperty($field)) {
+                $property = $reflectedClass->getProperty($field);
+                if (!$property->isPublic()) {
+                    throw new CannotFilterWithNonexistentKey(model: $model::class, key: $field);
+                }
+                $modelValue = $property->getValue($model);
+            } else {
+                throw new CannotFilterWithNonexistentKey(model: $model::class, key: $field);
+            }
+
+            if (is_array($modelValue) && !in_array($value, $modelValue, true)) {
+                return false;
+            }
+
+            if (!is_array($modelValue) && $modelValue !== $value) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/DeferredDynamoDbRepositoryIntegrationTest.php
+++ b/tests/DeferredDynamoDbRepositoryIntegrationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use AsyncAws\Core\Configuration;
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbRepositoryFactory;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbTableManager;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
+use chrisjenkinson\DynamoDbReadModel\InputBuilder;
+use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
+use PHPUnit\Framework\TestCase;
+
+final class DeferredDynamoDbRepositoryIntegrationTest extends TestCase
+{
+    private const TABLE_NAME = 'deferred-table';
+
+    private const REPOSITORY_NAME = 'name';
+
+    public function test_deferred_save_flush_can_be_read_by_an_immediate_repository(): void
+    {
+        $factory = $this->createFactory();
+
+        $deferred = $factory->createDeferred(self::REPOSITORY_NAME, RepositoryTestReadModel::class);
+        $model    = new RepositoryTestReadModel('id', 'name', 'foo', []);
+
+        $deferred->save($model);
+        self::assertNull($factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class)->find('id'));
+
+        $deferred->flush();
+
+        self::assertEquals($model, $factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class)->find('id'));
+    }
+
+    public function test_deferred_remove_flush_can_be_read_by_an_immediate_repository(): void
+    {
+        $factory = $this->createFactory();
+        $model   = new RepositoryTestReadModel('id', 'name', 'foo', []);
+
+        $factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class)->save($model);
+
+        $deferred = $factory->createDeferred(self::REPOSITORY_NAME, RepositoryTestReadModel::class);
+        $deferred->remove('id');
+        self::assertEquals($model, $factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class)->find('id'));
+
+        $deferred->flush();
+
+        self::assertNull($factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class)->find('id'));
+    }
+
+    public function test_deferred_queries_merge_staged_saves_and_removes_against_dynamodb(): void
+    {
+        $factory = $this->createFactory();
+
+        $persisted = new RepositoryTestReadModel('persisted', 'persisted', 'matched', []);
+        $dirty     = new RepositoryTestReadModel('dirty', 'dirty', 'matched', []);
+
+        $factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class)->save($persisted);
+
+        $deferred = $factory->createDeferred(self::REPOSITORY_NAME, RepositoryTestReadModel::class);
+        $deferred->remove('persisted');
+        $deferred->save($dirty);
+
+        self::assertEquals([$dirty], $deferred->findAll());
+        self::assertEquals([$dirty], $deferred->findBy([
+            'foo' => 'matched',
+        ]));
+    }
+
+    public function test_deferred_queries_reject_rows_whose_physical_id_does_not_match_the_payload_id(): void
+    {
+        $factory = $this->createFactory();
+        $this->putSerializedReadModel('physical-id', new RepositoryTestReadModel('payload-id', 'name', 'foo', []));
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $factory->createDeferred(self::REPOSITORY_NAME, RepositoryTestReadModel::class)->findAll();
+    }
+
+    private function createFactory(): DynamoDbRepositoryFactory
+    {
+        $client = $this->createClient();
+
+        $tableManager = new DynamoDbTableManager($client, new InputBuilder(), self::TABLE_NAME);
+        $tableManager->deleteTable();
+        $tableManager->createTable();
+
+        return new DynamoDbRepositoryFactory($client, new SimpleInterfaceSerializer(), self::TABLE_NAME, new ReadModelSnapshotStore());
+    }
+
+    private function putSerializedReadModel(string $physicalId, RepositoryTestReadModel $model): void
+    {
+        $this->createClient()->putItem([
+            'TableName' => self::TABLE_NAME,
+            'Item'      => [
+                'Name' => new AttributeValue([
+                    'S' => self::REPOSITORY_NAME,
+                ]),
+                'Id' => new AttributeValue([
+                    'S' => $physicalId,
+                ]),
+                'Data' => new AttributeValue([
+                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                ]),
+            ],
+        ])->resolve();
+    }
+
+    private function createClient(): DynamoDbClient
+    {
+        return new DynamoDbClient(Configuration::create([
+            'endpoint'        => getenv('DYNAMODB_ENDPOINT') ?: 'http://dynamodb-local:8000',
+            'accessKeyId'     => getenv('AWS_ACCESS_KEY_ID') ?: 'none',
+            'accessKeySecret' => getenv('AWS_SECRET_ACCESS_KEY') ?: 'none',
+        ]));
+    }
+}

--- a/tests/DeferredDynamoDbRepositoryTest.php
+++ b/tests/DeferredDynamoDbRepositoryTest.php
@@ -20,6 +20,7 @@ use Broadway\Serializer\SimpleInterfaceSerializer;
 use chrisjenkinson\DynamoDbReadModel\DeferredDynamoDbRepository;
 use chrisjenkinson\DynamoDbReadModel\DeferredFlushFailed;
 use chrisjenkinson\DynamoDbReadModel\DeferredOperation;
+use chrisjenkinson\DynamoDbReadModel\DeferredRepositoryFactory;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbReadModelStorage;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbRepositoryFactory;
 use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
@@ -53,6 +54,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         );
 
         self::assertNotInstanceOf(FlushableRepository::class, $factory->create('name', RepositoryTestReadModel::class));
+        self::assertInstanceOf(DeferredRepositoryFactory::class, $factory);
         self::assertInstanceOf(FlushableRepository::class, $factory->createDeferred('name', RepositoryTestReadModel::class));
     }
 
@@ -91,6 +93,16 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $client->expects($this->never())->method('putItem');
 
         $this->createRepository($client)->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+    }
+
+    public function test_save_rejects_a_read_model_for_a_different_repository_class(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('putItem');
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->createRepository($client)->save(new UnexpectedSerializableReadModel('wrong-class'));
     }
 
     public function test_flush_persists_dirty_models(): void
@@ -204,6 +216,25 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         self::assertCount(1, $operations);
         self::assertInstanceOf(MutableRepositoryTestReadModel::class, $operations[0]->model);
         self::assertSame('saved', $operations[0]->model->getName());
+    }
+
+    public function test_find_all_preserves_the_identity_mapped_staged_save_snapshot(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor());
+
+        $repository = $this->createMutableRepository($client);
+        $repository->save(new MutableRepositoryTestReadModel('id', 'saved'));
+
+        $found = $repository->find('id');
+        self::assertInstanceOf(MutableRepositoryTestReadModel::class, $found);
+        $found->rename('mutated');
+
+        $all = $repository->findAll();
+
+        self::assertCount(1, $all);
+        self::assertSame($found, $all[0]);
+        self::assertSame('mutated', $all[0]->getName());
     }
 
     public function test_remove_marks_the_model_removed_without_deleting_immediately(): void

--- a/tests/DeferredDynamoDbRepositoryTest.php
+++ b/tests/DeferredDynamoDbRepositoryTest.php
@@ -759,10 +759,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     {
         return new DeferredDynamoDbRepository(
             $this->createStorage($client, RepositoryTestReadModel::class),
-            new ReadModelFieldMatcher(),
-            'table',
-            'name',
-            RepositoryTestReadModel::class
+            new ReadModelFieldMatcher()
         );
     }
 
@@ -770,10 +767,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     {
         return new DeferredDynamoDbRepository(
             $this->createStorage($client, MutableRepositoryTestReadModel::class),
-            new ReadModelFieldMatcher(),
-            'table',
-            'name',
-            MutableRepositoryTestReadModel::class
+            new ReadModelFieldMatcher()
         );
     }
 

--- a/tests/DeferredDynamoDbRepositoryTest.php
+++ b/tests/DeferredDynamoDbRepositoryTest.php
@@ -1,0 +1,921 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Input\PutItemInput;
+use AsyncAws\DynamoDb\Result\DeleteItemOutput;
+use AsyncAws\DynamoDb\Result\GetItemOutput;
+use AsyncAws\DynamoDb\Result\PutItemOutput;
+use AsyncAws\DynamoDb\Result\QueryOutput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use Broadway\ReadModel\Repository;
+use Broadway\ReadModel\SerializableReadModel;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\DeferredDynamoDbRepository;
+use chrisjenkinson\DynamoDbReadModel\DeferredFlushFailed;
+use chrisjenkinson\DynamoDbReadModel\DeferredOperation;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbReadModelStorage;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbRepositoryFactory;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
+use chrisjenkinson\DynamoDbReadModel\FlushableRepository;
+use chrisjenkinson\DynamoDbReadModel\InputBuilder;
+use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
+use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelFieldMatcher;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+final class DeferredDynamoDbRepositoryTest extends TestCase
+{
+    public function test_it_is_a_broadway_repository_with_an_explicit_flush_boundary(): void
+    {
+        $repository = $this->createRepository($this->createMock(DynamoDbClient::class));
+
+        self::assertInstanceOf(Repository::class, $repository);
+        self::assertInstanceOf(FlushableRepository::class, $repository);
+    }
+
+    public function test_factory_creation_is_explicitly_deferred(): void
+    {
+        $factory = new DynamoDbRepositoryFactory(
+            $this->createMock(DynamoDbClient::class),
+            new SimpleInterfaceSerializer(),
+            'table',
+            new ReadModelSnapshotStore()
+        );
+
+        self::assertNotInstanceOf(FlushableRepository::class, $factory->create('name', RepositoryTestReadModel::class));
+        self::assertInstanceOf(FlushableRepository::class, $factory->createDeferred('name', RepositoryTestReadModel::class));
+    }
+
+    public function test_find_uses_an_identity_map_before_reading_from_dynamodb(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
+
+        $repository = $this->createRepository($client);
+
+        $first  = $repository->find('id');
+        $second = $repository->find('id');
+
+        self::assertInstanceOf(RepositoryTestReadModel::class, $first);
+        self::assertSame($first, $second);
+    }
+
+    public function test_find_accepts_a_stringable_id(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('getItem');
+
+        $repository = $this->createRepository($client);
+        $model      = new RepositoryTestReadModel('id', 'name', 'foo', []);
+
+        $repository->save($model);
+
+        self::assertEquals($model, $repository->find($this->stringableId('id')));
+    }
+
+    public function test_save_marks_the_model_dirty_without_writing_immediately(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('putItem');
+
+        $this->createRepository($client)->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+    }
+
+    public function test_flush_persists_dirty_models(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+
+        $repository->flush();
+
+        self::assertTrue($putItemOutput->info()['resolved']);
+    }
+
+    public function test_repeated_saves_collapse_to_one_final_write_on_flush(): void
+    {
+        $putItemOutput   = new PutItemOutput($this->createResponse());
+        $writtenPayloads = [];
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturnCallback(function ($input) use (&$writtenPayloads, $putItemOutput): PutItemOutput {
+                $writtenPayloads[] = $this->decodePutItemPayload($input);
+
+                return $putItemOutput;
+            });
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('id', 'first', 'foo', []));
+        $repository->save(new RepositoryTestReadModel('id', 'second', 'foo', []));
+
+        $repository->flush();
+
+        self::assertSame('second', $writtenPayloads[0]['payload']['name']);
+    }
+
+    public function test_save_captures_the_model_state_when_save_is_called(): void
+    {
+        $putItemOutput   = new PutItemOutput($this->createResponse());
+        $writtenPayloads = [];
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturnCallback(function ($input) use (&$writtenPayloads, $putItemOutput): PutItemOutput {
+                $writtenPayloads[] = $this->decodePutItemPayload($input);
+
+                return $putItemOutput;
+            });
+
+        $repository = $this->createMutableRepository($client);
+        $model      = new MutableRepositoryTestReadModel('id', 'saved');
+
+        $repository->save($model);
+        $model->rename('mutated');
+
+        $repository->flush();
+
+        self::assertSame('saved', $writtenPayloads[0]['payload']['name']);
+    }
+
+    public function test_find_returns_the_saved_snapshot_state_after_the_original_model_is_mutated(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('getItem');
+
+        $repository = $this->createMutableRepository($client);
+        $model      = new MutableRepositoryTestReadModel('id', 'saved');
+
+        $repository->save($model);
+        $model->rename('mutated');
+
+        $found = $repository->find('id');
+
+        self::assertInstanceOf(MutableRepositoryTestReadModel::class, $found);
+        self::assertSame('saved', $found->getName());
+    }
+
+    public function test_pending_save_operations_expose_the_saved_snapshot_state(): void
+    {
+        $repository = $this->createMutableRepository($this->createMock(DynamoDbClient::class));
+        $model      = new MutableRepositoryTestReadModel('id', 'saved');
+
+        $repository->save($model);
+        $model->rename('mutated');
+
+        $operations = $repository->pendingOperations();
+
+        self::assertCount(1, $operations);
+        self::assertInstanceOf(MutableRepositoryTestReadModel::class, $operations[0]->model);
+        self::assertSame('saved', $operations[0]->model->getName());
+    }
+
+    public function test_pending_save_operations_ignore_mutations_to_the_identity_mapped_snapshot(): void
+    {
+        $repository = $this->createMutableRepository($this->createMock(DynamoDbClient::class));
+        $model      = new MutableRepositoryTestReadModel('id', 'saved');
+
+        $repository->save($model);
+
+        $found = $repository->find('id');
+        self::assertInstanceOf(MutableRepositoryTestReadModel::class, $found);
+        $found->rename('mutated');
+
+        $operations = $repository->pendingOperations();
+
+        self::assertCount(1, $operations);
+        self::assertInstanceOf(MutableRepositoryTestReadModel::class, $operations[0]->model);
+        self::assertSame('saved', $operations[0]->model->getName());
+    }
+
+    public function test_remove_marks_the_model_removed_without_deleting_immediately(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('deleteItem');
+
+        $this->createRepository($client)->remove('id');
+    }
+
+    public function test_remove_accepts_a_stringable_id(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('getItem');
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+        $repository->remove($this->stringableId('id'));
+
+        self::assertNull($repository->find('id'));
+    }
+
+    public function test_removed_items_are_hidden_from_find_until_saved_again(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('getItem');
+
+        $repository = $this->createRepository($client);
+        $repository->remove('id');
+
+        self::assertNull($repository->find('id'));
+    }
+
+    public function test_flush_persists_pending_removes(): void
+    {
+        $deleteItemOutput = new DeleteItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('deleteItem')->willReturn($deleteItemOutput);
+
+        $repository = $this->createRepository($client);
+        $repository->remove('id');
+
+        $repository->flush();
+
+        self::assertTrue($deleteItemOutput->info()['resolved']);
+    }
+
+    public function test_flush_deletes_each_removed_id(): void
+    {
+        $deletedIds = [];
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->exactly(2))
+            ->method('deleteItem')
+            ->willReturnCallback(function ($input) use (&$deletedIds): DeleteItemOutput {
+                $deletedIds[] = $input->getKey()['Id']->getS();
+
+                return new DeleteItemOutput($this->createResponse());
+            });
+
+        $repository = $this->createRepository($client);
+        $repository->remove('first');
+        $repository->remove('second');
+
+        $repository->flush();
+
+        self::assertSame(['first', 'second'], $deletedIds);
+    }
+
+    public function test_saving_a_removed_item_cancels_the_pending_remove(): void
+    {
+        $putItemOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('deleteItem');
+        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+
+        $repository = $this->createRepository($client);
+        $repository->remove('id');
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+
+        $repository->flush();
+    }
+
+    public function test_removing_a_saved_item_flushes_a_delete(): void
+    {
+        $deleteItemOutput = new DeleteItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('putItem');
+        $client->expects($this->once())->method('deleteItem')->willReturn($deleteItemOutput);
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+        $repository->remove('id');
+
+        $repository->flush();
+    }
+
+    public function test_pending_operations_are_available_for_inspection(): void
+    {
+        $repository = $this->createRepository($this->createMock(DynamoDbClient::class));
+        $repository->save(new RepositoryTestReadModel('saved', 'name', 'foo', []));
+        $repository->remove('removed');
+
+        $operations = $repository->pendingOperations();
+
+        self::assertCount(2, $operations);
+        self::assertSame(DeferredOperation::REMOVE, $operations[0]->operation);
+        self::assertSame('removed', $operations[0]->id);
+        self::assertSame(DeferredOperation::SAVE, $operations[1]->operation);
+        self::assertSame('saved', $operations[1]->id);
+    }
+
+    public function test_clear_discards_managed_dirty_and_removed_state(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())->method('deleteItem');
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('removed', 'name', 'foo', [])));
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('dirty', 'name', 'foo', []));
+        $repository->remove('removed');
+
+        $repository->clear();
+        $repository->flush();
+
+        self::assertInstanceOf(RepositoryTestReadModel::class, $repository->find('removed'));
+    }
+
+    public function test_find_all_overlays_dirty_and_removed_state_on_persisted_models(): void
+    {
+        $persisted = new RepositoryTestReadModel('persisted', 'persisted', 'foo', []);
+        $dirty     = new RepositoryTestReadModel('dirty', 'dirty', 'foo', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+
+        $repository = $this->createRepository($client);
+        $repository->remove('persisted');
+        $repository->save($dirty);
+
+        self::assertEquals([$dirty], $repository->findAll());
+    }
+
+    public function test_find_all_continues_past_removed_persisted_models(): void
+    {
+        $removed = new RepositoryTestReadModel('removed', 'removed', 'foo', []);
+        $kept    = new RepositoryTestReadModel('kept', 'kept', 'foo', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($removed, $kept));
+
+        $repository = $this->createRepository($client);
+        $repository->remove('removed');
+
+        self::assertEquals([$kept], $repository->findAll());
+    }
+
+    public function test_find_rejects_rows_whose_physical_id_does_not_match_the_payload_id(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', [])));
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->createRepository($client)->find('physical-id');
+    }
+
+    public function test_find_all_rejects_rows_whose_physical_id_does_not_match_the_payload_id(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputForPhysicalId('physical-id', new RepositoryTestReadModel('payload-id', 'name', 'foo', [])));
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->createRepository($client)->findAll();
+    }
+
+    public function test_find_all_preserves_the_identity_mapped_model_when_persisted_state_is_reloaded(): void
+    {
+        $first  = new RepositoryTestReadModel('id', 'first', 'foo', []);
+        $second = new RepositoryTestReadModel('id', 'second', 'foo', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($second));
+
+        $repository = $this->createRepository($client);
+        $repository->save($first);
+
+        self::assertEquals($first, $repository->findAll()[0]);
+    }
+
+    public function test_find_all_preserves_the_identity_mapped_model_loaded_by_find_when_persisted_state_is_reloaded(): void
+    {
+        $first  = new RepositoryTestReadModel('id', 'first', 'foo', []);
+        $second = new RepositoryTestReadModel('id', 'second', 'foo', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('getItem')->willReturn($this->getItemOutputFor($first));
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($second));
+
+        $repository = $this->createRepository($client);
+        $model      = $repository->find('id');
+
+        self::assertSame($model, $repository->findAll()[0]);
+    }
+
+    public function test_find_by_filters_the_deferred_view(): void
+    {
+        $persisted = new RepositoryTestReadModel('persisted', 'persisted', 'unmatched', []);
+        $dirty     = new RepositoryTestReadModel('dirty', 'dirty', 'matched', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+
+        $repository = $this->createRepository($client);
+        $repository->save($dirty);
+
+        self::assertEquals([$dirty], $repository->findBy([
+            'foo' => 'matched',
+        ]));
+    }
+
+    public function test_find_by_excludes_pending_saves_that_do_not_match_the_filter(): void
+    {
+        $persisted = new RepositoryTestReadModel('persisted', 'persisted', 'matched', []);
+        $dirty     = new RepositoryTestReadModel('dirty', 'dirty', 'unmatched', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+
+        $repository = $this->createRepository($client);
+        $repository->save($dirty);
+
+        self::assertEquals([$persisted], $repository->findBy([
+            'foo' => 'matched',
+        ]));
+    }
+
+    public function test_find_by_excludes_persisted_models_updated_in_memory_to_no_longer_match(): void
+    {
+        $persisted = new RepositoryTestReadModel('id', 'name', 'matched', []);
+        $dirty     = new RepositoryTestReadModel('id', 'name', 'unmatched', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+
+        $repository = $this->createRepository($client);
+        $repository->save($dirty);
+
+        self::assertSame([], $repository->findBy([
+            'foo' => 'matched',
+        ]));
+    }
+
+    public function test_find_by_includes_persisted_models_updated_in_memory_to_match(): void
+    {
+        $persisted = new RepositoryTestReadModel('id', 'name', 'unmatched', []);
+        $dirty     = new RepositoryTestReadModel('id', 'name', 'matched', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+
+        $repository = $this->createRepository($client);
+        $repository->save($dirty);
+
+        self::assertEquals([$dirty], $repository->findBy([
+            'foo' => 'matched',
+        ]));
+    }
+
+    public function test_find_by_excludes_models_removed_by_id(): void
+    {
+        $persisted = new RepositoryTestReadModel('id', 'name', 'matched', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+
+        $repository = $this->createRepository($client);
+        $repository->remove('id');
+
+        self::assertSame([], $repository->findBy([
+            'foo' => 'matched',
+        ]));
+    }
+
+    public function test_find_by_rejects_rows_whose_physical_id_does_not_match_the_payload_id(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputForPhysicalId('physical-id', new RepositoryTestReadModel('payload-id', 'name', 'matched', [])));
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->createRepository($client)->findBy([
+            'foo' => 'matched',
+        ]);
+    }
+
+    public function test_find_by_filters_array_getters_by_contained_values(): void
+    {
+        $matching    = new RepositoryTestReadModel('matching', 'matching', 'foo', ['matched']);
+        $notMatching = new RepositoryTestReadModel('not-matching', 'not-matching', 'foo', ['other']);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($matching, $notMatching));
+
+        $repository = $this->createRepository($client);
+
+        self::assertEquals([$matching], $repository->findBy([
+            'array' => 'matched',
+        ]));
+    }
+
+    public function test_find_by_uses_public_getter_naming(): void
+    {
+        $matching    = new RepositoryTestReadModel('matching', 'matched', 'foo', []);
+        $notMatching = new RepositoryTestReadModel('not-matching', 'other', 'foo', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($matching, $notMatching));
+
+        $repository = $this->createRepository($client);
+
+        self::assertEquals([$matching], $repository->findBy([
+            'name' => 'matched',
+        ]));
+    }
+
+    public function test_failed_flush_preserves_pending_dirty_state_for_retry(): void
+    {
+        $successfulOutput = new PutItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->exactly(2))
+            ->method('putItem')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \RuntimeException('failed')),
+                $successfulOutput
+            );
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+
+        try {
+            $repository->flush();
+            self::fail('Expected the first flush to fail.');
+        } catch (\RuntimeException) {
+        }
+
+        $repository->flush();
+    }
+
+    public function test_failed_flush_reports_the_failed_dirty_operation(): void
+    {
+        $previous = new \RuntimeException('failed');
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willThrowException($previous);
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+
+        try {
+            $repository->flush();
+            self::fail('Expected flush to fail.');
+        } catch (DeferredFlushFailed $exception) {
+            self::assertSame(0, $exception->getCode());
+            self::assertSame($previous, $exception->getPrevious());
+            self::assertSame(DeferredOperation::SAVE, $exception->operation);
+            self::assertSame('id', $exception->id);
+            self::assertSame('table', $exception->table);
+            self::assertSame('name', $exception->repositoryName);
+            self::assertSame(RepositoryTestReadModel::class, $exception->readModelClass);
+        }
+    }
+
+    public function test_failed_flush_reports_caller_supplied_context(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willThrowException(new \RuntimeException('failed'));
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+
+        try {
+            $repository->flushWithContext([
+                'tenantId'      => 'tenant-1',
+                'projector'     => 'Projector',
+                'sourceEventId' => 'event-1',
+            ]);
+            self::fail('Expected flush to fail.');
+        } catch (DeferredFlushFailed $exception) {
+            self::assertSame([
+                'tenantId'      => 'tenant-1',
+                'projector'     => 'Projector',
+                'sourceEventId' => 'event-1',
+            ], $exception->context);
+        }
+    }
+
+    public function test_failed_flush_after_successful_dirty_write_retries_only_remaining_dirty_models(): void
+    {
+        $attemptedIds = [];
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->exactly(4))
+            ->method('putItem')
+            ->willReturnCallback(function ($input) use (&$attemptedIds): PutItemOutput {
+                $id             = $input->getItem()['Id']->getS();
+                $attemptedIds[] = $id;
+
+                if ('second' === $id && 2 === count($attemptedIds)) {
+                    throw new \RuntimeException('failed second');
+                }
+
+                return new PutItemOutput($this->createResponse());
+            });
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('first', 'first', 'foo', []));
+        $repository->save(new RepositoryTestReadModel('second', 'second', 'foo', []));
+        $repository->save(new RepositoryTestReadModel('third', 'third', 'foo', []));
+
+        try {
+            $repository->flush();
+            self::fail('Expected flush to fail.');
+        } catch (DeferredFlushFailed) {
+        }
+
+        $operations = $repository->pendingOperations();
+        self::assertCount(2, $operations);
+        self::assertSame(['second', 'third'], array_map(
+            static fn (DeferredOperation $operation): string => $operation->id,
+            $operations
+        ));
+
+        $repository->flush();
+
+        self::assertSame(['first', 'second', 'second', 'third'], $attemptedIds);
+    }
+
+    public function test_failed_flush_preserves_pending_removed_state_for_retry(): void
+    {
+        $successfulOutput = new DeleteItemOutput($this->createResponse());
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->exactly(2))
+            ->method('deleteItem')
+            ->willReturnOnConsecutiveCalls(
+                $this->throwException(new \RuntimeException('failed')),
+                $successfulOutput
+            );
+
+        $repository = $this->createRepository($client);
+        $repository->remove('id');
+
+        try {
+            $repository->flush();
+            self::fail('Expected the first flush to fail.');
+        } catch (\RuntimeException) {
+        }
+
+        $operations = $repository->pendingOperations();
+        self::assertCount(1, $operations);
+        self::assertSame(DeferredOperation::REMOVE, $operations[0]->operation);
+        self::assertSame('id', $operations[0]->id);
+
+        $repository->flush();
+    }
+
+    public function test_failed_flush_after_successful_remove_keeps_only_later_operations_pending(): void
+    {
+        $attemptedRemoves = [];
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->exactly(4))
+            ->method('deleteItem')
+            ->willReturnCallback(function ($input) use (&$attemptedRemoves): DeleteItemOutput {
+                $id                 = $input->getKey()['Id']->getS();
+                $attemptedRemoves[] = $id;
+
+                if ('second' === $id && 2 === count($attemptedRemoves)) {
+                    throw new \RuntimeException('failed second');
+                }
+
+                return new DeleteItemOutput($this->createResponse());
+            });
+
+        $repository = $this->createRepository($client);
+        $repository->remove('first');
+        $repository->remove('second');
+        $repository->remove('third');
+
+        try {
+            $repository->flush();
+            self::fail('Expected flush to fail.');
+        } catch (DeferredFlushFailed) {
+        }
+
+        $operations = $repository->pendingOperations();
+        self::assertCount(2, $operations);
+        self::assertSame(['second', 'third'], array_map(
+            static fn (DeferredOperation $operation): string => $operation->id,
+            $operations
+        ));
+
+        $repository->flush();
+
+        self::assertSame(['first', 'second', 'second', 'third'], $attemptedRemoves);
+    }
+
+    public function test_failed_flush_reports_the_failed_remove_operation(): void
+    {
+        $previous = new \RuntimeException('failed');
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('deleteItem')
+            ->willThrowException($previous);
+
+        $repository = $this->createRepository($client);
+        $repository->remove('id');
+
+        try {
+            $repository->flush();
+            self::fail('Expected flush to fail.');
+        } catch (DeferredFlushFailed $exception) {
+            self::assertSame($previous, $exception->getPrevious());
+            self::assertSame(DeferredOperation::REMOVE, $exception->operation);
+            self::assertSame('id', $exception->id);
+            self::assertSame('table', $exception->table);
+            self::assertSame('name', $exception->repositoryName);
+            self::assertSame(RepositoryTestReadModel::class, $exception->readModelClass);
+        }
+    }
+
+    private function createRepository(DynamoDbClient $client): DeferredDynamoDbRepository
+    {
+        return new DeferredDynamoDbRepository(
+            $this->createStorage($client, RepositoryTestReadModel::class),
+            new ReadModelFieldMatcher(),
+            'table',
+            'name',
+            RepositoryTestReadModel::class
+        );
+    }
+
+    private function createMutableRepository(DynamoDbClient $client): DeferredDynamoDbRepository
+    {
+        return new DeferredDynamoDbRepository(
+            $this->createStorage($client, MutableRepositoryTestReadModel::class),
+            new ReadModelFieldMatcher(),
+            'table',
+            'name',
+            MutableRepositoryTestReadModel::class
+        );
+    }
+
+    private function createStorage(DynamoDbClient $client, string $class): DynamoDbReadModelStorage
+    {
+        return new DynamoDbReadModelStorage(
+            $client,
+            new InputBuilder(),
+            new SimpleInterfaceSerializer(),
+            new JsonEncoder(),
+            new JsonDecoder(),
+            'table',
+            'name',
+            $class,
+            new ReadModelSnapshotStore()
+        );
+    }
+
+    private function getItemOutputFor(RepositoryTestReadModel $model): GetItemOutput
+    {
+        $output = $this->createStub(GetItemOutput::class);
+        $output->method('getItem')->willReturn([
+            'Data' => new AttributeValue([
+                'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+            ]),
+        ]);
+
+        return $output;
+    }
+
+    private function queryOutputFor(RepositoryTestReadModel ...$models): QueryOutput
+    {
+        $output = $this->createStub(QueryOutput::class);
+        $output->method('getCount')->willReturn(count($models));
+
+        $items = array_map(function (RepositoryTestReadModel $model): array {
+            return [
+                'Id' => new AttributeValue([
+                    'S' => $model->getId(),
+                ]),
+                'Data' => new AttributeValue([
+                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                ]),
+            ];
+        }, $models);
+
+        $output->method('getItems')->willReturn($items);
+
+        return $output;
+    }
+
+    private function queryOutputForPhysicalId(string $physicalId, RepositoryTestReadModel $model): QueryOutput
+    {
+        $output = $this->createStub(QueryOutput::class);
+        $output->method('getCount')->willReturn(1);
+        $output->method('getItems')->willReturn([
+            [
+                'Id' => new AttributeValue([
+                    'S' => $physicalId,
+                ]),
+                'Data' => new AttributeValue([
+                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                ]),
+            ],
+        ]);
+
+        return $output;
+    }
+
+    private function createResponse(): Response
+    {
+        $client = new MockHttpClient(new SimpleMockedResponse('{}'));
+
+        return new Response($client->request('POST', 'http://localhost'), $client, new NullLogger());
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function decodePutItemPayload(PutItemInput $input): array
+    {
+        $data = $input->getItem()['Data']->getS();
+        self::assertIsString($data);
+
+        return json_decode($data, true, flags: JSON_THROW_ON_ERROR);
+    }
+
+    private function stringableId(string $id): object
+    {
+        return new class($id) {
+            public function __construct(
+                private readonly string $id
+            ) {
+            }
+
+            public function __toString(): string
+            {
+                return $this->id;
+            }
+        };
+    }
+}
+
+final class MutableRepositoryTestReadModel implements SerializableReadModel
+{
+    public function __construct(
+        private readonly string $id,
+        private string $name
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function rename(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return array{id: string, name: string}
+     */
+    public function serialize(): array
+    {
+        return [
+            'id'   => $this->id,
+            'name' => $this->name,
+        ];
+    }
+
+    /**
+     * @param array{id: string, name: string} $data
+     */
+    public static function deserialize(array $data): self
+    {
+        return new self($data['id'], $data['name']);
+    }
+}

--- a/tests/DynamoDbRepositoryResponseResolutionTest.php
+++ b/tests/DynamoDbRepositoryResponseResolutionTest.php
@@ -11,10 +11,12 @@ use AsyncAws\DynamoDb\Result\DeleteItemOutput;
 use AsyncAws\DynamoDb\Result\PutItemOutput;
 use Broadway\ReadModel\Testing\RepositoryTestReadModel;
 use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbReadModelStorage;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbRepository;
 use chrisjenkinson\DynamoDbReadModel\InputBuilder;
 use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
 use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelFieldMatcher;
 use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
@@ -53,15 +55,18 @@ final class DynamoDbRepositoryResponseResolutionTest extends TestCase
     private function createRepository(DynamoDbClient $client): DynamoDbRepository
     {
         return new DynamoDbRepository(
-            $client,
-            new InputBuilder(),
-            new SimpleInterfaceSerializer(),
-            new JsonEncoder(),
-            new JsonDecoder(),
-            'table',
-            'name',
-            RepositoryTestReadModel::class,
-            new ReadModelSnapshotStore()
+            new DynamoDbReadModelStorage(
+                $client,
+                new InputBuilder(),
+                new SimpleInterfaceSerializer(),
+                new JsonEncoder(),
+                new JsonDecoder(),
+                'table',
+                'name',
+                RepositoryTestReadModel::class,
+                new ReadModelSnapshotStore()
+            ),
+            new ReadModelFieldMatcher()
         );
     }
 

--- a/tests/DynamoDbRepositorySnapshotSuppressionTest.php
+++ b/tests/DynamoDbRepositorySnapshotSuppressionTest.php
@@ -15,6 +15,7 @@ use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use Broadway\ReadModel\Testing\RepositoryTestReadModel;
 use Broadway\Serializer\SimpleInterfaceSerializer;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbRepositoryFactory;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
 use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
 use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshot;
 use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
@@ -129,21 +130,19 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $repository->save($model);
     }
 
-    public function test_it_writes_when_find_observes_a_row_whose_physical_id_does_not_match_the_payload_id(): void
+    public function test_it_rejects_find_rows_whose_physical_id_does_not_match_the_payload_id(): void
     {
-        $putItemOutput = new PutItemOutput($this->createResponse());
-
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', [])));
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->never())->method('putItem');
 
         $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
-        $model      = $repository->find('physical-id');
-        self::assertInstanceOf(RepositoryTestReadModel::class, $model);
 
-        $repository->save($model);
+        $this->expectException(UnexpectedReadModel::class);
+
+        $repository->find('physical-id');
     }
 
     public function test_it_shares_snapshots_across_repositories_created_by_the_same_factory(): void
@@ -268,23 +267,36 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $repository->save(new RepositoryTestReadModel('id', 'name', 'not-matching', []));
     }
 
-    public function test_it_does_not_snapshot_models_loaded_by_query_when_the_physical_id_differs_from_the_payload_id(): void
+    public function test_it_rejects_query_rows_whose_physical_id_does_not_match_the_payload_id(): void
     {
-        $putItemOutput = new PutItemOutput($this->createResponse());
-
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects($this->once())
             ->method('query')
             ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', []), 'physical-id'));
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->never())->method('putItem');
 
         $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
 
-        $models = $repository->findAll();
-        self::assertCount(1, $models);
-        self::assertContainsOnlyInstancesOf(RepositoryTestReadModel::class, $models);
+        $this->expectException(UnexpectedReadModel::class);
 
-        $repository->save($models[0]);
+        $repository->findAll();
+    }
+
+    public function test_it_rejects_find_by_rows_whose_physical_id_does_not_match_the_payload_id(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', []), 'physical-id'));
+        $client->expects($this->never())->method('putItem');
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $repository->findBy([
+            'foo' => 'foo',
+        ]);
     }
 
     private function createFactory(DynamoDbClient $client): DynamoDbRepositoryFactory

--- a/tests/DynamoDbRepositorySnapshotSuppressionTest.php
+++ b/tests/DynamoDbRepositorySnapshotSuppressionTest.php
@@ -72,6 +72,18 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
     }
 
+    public function test_it_rejects_saving_a_read_model_for_a_different_repository_class(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())->method('putItem');
+
+        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $repository->save(new UnexpectedSerializableReadModel('wrong-class'));
+    }
+
     public function test_it_skips_the_second_physical_write_when_the_same_state_was_already_saved(): void
     {
         $putItemOutput = new PutItemOutput($this->createResponse());

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -42,10 +42,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         return $factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class);
     }
 
-    /**
-     * @test
-     */
-    public function it_removes_only_one_read_model_when_multiple_are_saved(): void
+    public function test_it_removes_only_one_read_model_when_multiple_are_saved(): void
     {
         $model1 = $this->createReadModel('1', 'name1', 'foo1');
         $model2 = $this->createReadModel('2', 'name2', 'foo2');
@@ -58,10 +55,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         $this->assertEquals([$model2], $this->repository->findAll());
     }
 
-    /**
-     * @test
-     */
-    public function it_finds_read_models_by_public_getter(): void
+    public function test_it_finds_read_models_by_public_getter(): void
     {
         $model1 = $this->createReadModel('1', 'name1', 'foo1');
         $model2 = $this->createReadModel('2', 'name2', 'foo2');
@@ -74,10 +68,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         ]));
     }
 
-    /**
-     * @test
-     */
-    public function it_rejects_unexpected_serialized_classes_before_deserializing_them(): void
+    public function test_it_rejects_unexpected_serialized_classes_before_deserializing_them(): void
     {
         UnexpectedSerializableReadModel::$deserializeWasCalled = false;
 
@@ -110,10 +101,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         }
     }
 
-    /**
-     * @test
-     */
-    public function it_rejects_serialized_data_without_a_string_class(): void
+    public function test_it_rejects_serialized_data_without_a_string_class(): void
     {
         $this->createDynamoDbClient()->putItem([
             'TableName' => self::TABLE_NAME,
@@ -140,10 +128,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         $this->repository->find('invalid-class');
     }
 
-    /**
-     * @test
-     */
-    public function it_rejects_deserialized_models_that_do_not_implement_identifiable(): void
+    public function test_it_rejects_deserialized_models_that_do_not_implement_identifiable(): void
     {
         $client = $this->createDynamoDbClient();
         $client->putItem([
@@ -186,10 +171,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         $repository->find('non-identifiable');
     }
 
-    /**
-     * @test
-     */
-    public function it_rejects_rows_whose_physical_id_does_not_match_the_payload_id_when_finding_one_model(): void
+    public function test_it_rejects_rows_whose_physical_id_does_not_match_the_payload_id_when_finding_one_model(): void
     {
         $this->putSerializedReadModel('physical-id', new RepositoryTestReadModel('payload-id', 'name', 'foo', []));
 
@@ -198,10 +180,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         $this->repository->find('physical-id');
     }
 
-    /**
-     * @test
-     */
-    public function it_rejects_rows_whose_physical_id_does_not_match_the_payload_id_when_querying_models(): void
+    public function test_it_rejects_rows_whose_physical_id_does_not_match_the_payload_id_when_querying_models(): void
     {
         $this->putSerializedReadModel('physical-id', new RepositoryTestReadModel('payload-id', 'name', 'foo', []));
 

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -11,6 +11,7 @@ use Broadway\ReadModel\Repository;
 use Broadway\ReadModel\Testing\RepositoryTestCase;
 use Broadway\ReadModel\Testing\RepositoryTestReadModel;
 use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbReadModelStorage;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbRepository;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbRepositoryFactory;
 use chrisjenkinson\DynamoDbReadModel\DynamoDbTableManager;
@@ -18,6 +19,7 @@ use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
 use chrisjenkinson\DynamoDbReadModel\InputBuilder;
 use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
 use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelFieldMatcher;
 use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
 
 final class DynamoDbRepositoryTest extends RepositoryTestCase
@@ -165,20 +167,67 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         ])->resolve();
 
         $repository = new DynamoDbRepository(
-            $client,
-            new InputBuilder(),
-            new SimpleInterfaceSerializer(),
-            new JsonEncoder(),
-            new JsonDecoder(),
-            self::TABLE_NAME,
-            'non-identifiable',
-            NonIdentifiableSerializableReadModel::class,
-            new ReadModelSnapshotStore()
+            new DynamoDbReadModelStorage(
+                $client,
+                new InputBuilder(),
+                new SimpleInterfaceSerializer(),
+                new JsonEncoder(),
+                new JsonDecoder(),
+                self::TABLE_NAME,
+                'non-identifiable',
+                NonIdentifiableSerializableReadModel::class,
+                new ReadModelSnapshotStore()
+            ),
+            new ReadModelFieldMatcher()
         );
 
         $this->expectException(UnexpectedReadModel::class);
 
         $repository->find('non-identifiable');
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_rows_whose_physical_id_does_not_match_the_payload_id_when_finding_one_model(): void
+    {
+        $this->putSerializedReadModel('physical-id', new RepositoryTestReadModel('payload-id', 'name', 'foo', []));
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->repository->find('physical-id');
+    }
+
+    /**
+     * @test
+     */
+    public function it_rejects_rows_whose_physical_id_does_not_match_the_payload_id_when_querying_models(): void
+    {
+        $this->putSerializedReadModel('physical-id', new RepositoryTestReadModel('payload-id', 'name', 'foo', []));
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->repository->findBy([
+            'foo' => 'foo',
+        ]);
+    }
+
+    private function putSerializedReadModel(string $physicalId, RepositoryTestReadModel $model): void
+    {
+        $this->createDynamoDbClient()->putItem([
+            'TableName' => self::TABLE_NAME,
+            'Item'      => [
+                'Name' => new AttributeValue([
+                    'S' => self::REPOSITORY_NAME,
+                ]),
+                'Id' => new AttributeValue([
+                    'S' => $physicalId,
+                ]),
+                'Data' => new AttributeValue([
+                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                ]),
+            ],
+        ])->resolve();
     }
 
     private function createDynamoDbClient(): DynamoDbClient


### PR DESCRIPTION
Adds an explicit deferred persistence mode for DynamoDB-backed Broadway read-model repositories. The new repository remains Broadway-compatible for projectors, stages save-time serialized state in memory, collapses repeated saves by read-model id, and flushes pending saves/removes only at an explicit boundary.

The implementation extracts shared DynamoDB storage and field-matching collaborators so immediate and deferred repositories use the same serialization, read, write, mismatch validation, snapshot suppression, and findBy matching behavior. Rows whose physical DynamoDB Id differs from the serialized read-model id are treated as invalid stored data and rejected on read, and saves now reject read models for the wrong configured repository class before writing. A small DeferredRepositoryFactory interface exposes the package-specific createDeferred() capability without relying on Broadway's narrower factory contract.

Docs cover the deferred lifecycle and caveats:
- use createDeferred() to opt in;
- use flush(); clear(); checkpoints for long-running replays/seeds;
- prefer the factory construction path;
- findBy() remains available for compatibility but should not be used for write-side invariants or duplicate guards.