### PR TITLE
Optimize ID-constrained read model lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,32 @@ The DynamoDB `Id` value is required to match the serialized read model's
 treated as invalid stored data and rejected on read; repair those rows with
 explicit operational tooling rather than relying on repository normalization.
 
-`find($id)` uses the full primary key (`Name` + `Id`) and is the bounded lookup
-to prefer for production read paths. `findAll()` queries the full repository
-partition for the configured `Name` and returns every read model in memory.
-`findBy()` also queries the full repository partition, deserializes each read
-model, and then filters in PHP. For production-sized collections, avoid using
-`findAll()` or `findBy()` on request paths unless that full-partition work is
-intentional.
+`find($id)` uses the full primary key (`Name` + `Id`) and is a bounded lookup.
+`findBy()` also has bounded paths, but only when the criteria contain the exact,
+lowercase `id` field:
+
+- A non-empty string `id` uses `GetItem`. Any `id` value that is neither a
+  non-empty string nor an array, including an object or resource, returns `[]`
+  without making an AWS request. Arrays follow the list validation below.
+- A PHP list of ids uses `BatchGetItem`, split into requests of at most 100
+  keys. Every entry must be a non-empty string; a non-list array or invalid
+  entry throws `InvalidIdCriterion`. An empty list returns `[]` without making
+  an AWS request.
+- Duplicate ids are removed by first occurrence. Results follow that requested
+  order, with ids that do not exist omitted. Additional criteria are applied in
+  PHP only to this bounded set of loaded models.
+- For each chunk of at most 100 keys, unprocessed batch keys are retried with
+  jitter for up to four total attempts. If keys remain unresolved,
+  `BatchGetRetriesExhausted` reports the failure.
+
+The field name is case-sensitive. `Id`, `ID`, and other non-empty, non-ID
+criteria do not select these bounded paths: they query the full repository
+partition for the configured `Name`, deserialize its models, and filter in PHP
+unless the application models a separate indexed lookup. `findBy([])` returns
+`[]` without making an AWS request. `findAll()` queries and returns the full
+partition. For production-sized collections, avoid `findAll()` and non-ID
+`findBy()` calls on request paths unless that full-partition work is intentional.
+These optimizations do not change Broadway's `Repository` interface.
 
 ## Snapshot Store
 
@@ -154,17 +173,20 @@ $repository->flushWithContext([
 ]);
 ```
 
-`findAll()` and `findBy()` are merge-aware: they query DynamoDB and overlay
-pending local saves/removes before returning results. They still perform a
-DynamoDB query each time, and DynamoDB reads use the repository's normal
-consistency settings. Deferred mode makes this repository's staged changes
-visible; it does not make broad projection queries transactional or globally
-fresh.
+Deferred `findAll()` and `findBy()` results account for pending local state.
+`findAll()` and `findBy()` with non-empty non-ID criteria query DynamoDB each
+time and overlay pending local saves/removes; `findBy([])` returns `[]` without
+an AWS request. DynamoDB reads use the repository's normal consistency settings.
+For an ID-constrained `findBy()`, pending removals are excluded, managed and
+staged models are resolved locally, and only unresolved ids are fetched from
+DynamoDB. Deferred mode makes this repository's staged changes visible; it does
+not make broad projection queries transactional or globally fresh.
 
-`findBy()` remains available for Broadway compatibility and small read-side
-collections. Do not use it as a write-side invariant or duplicate guard during
-command handling, seeding, or projection rebuilds. Model those cases as
-deterministic lookup read models and query them with `find($id)`.
+`findBy()` remains available for Broadway compatibility. Its non-ID form is
+intended for small read-side collections because it performs the full-partition
+work described above. Do not use `findBy()` as a write-side invariant or
+duplicate guard during command handling, seeding, or projection rebuilds. Model
+those cases as deterministic lookup read models and query them with `find($id)`.
 
 The identity map is scoped to the deferred repository instance. It can return a
 cached model even if another process changes DynamoDB while the deferred

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,11 @@
          failOnRisky="true"
          failOnWarning="true"
          verbose="true">
+    <php>
+        <env name="DYNAMODB_ENDPOINT" value="http://127.0.0.1:8000"/>
+        <env name="AWS_ACCESS_KEY_ID" value="none"/>
+        <env name="AWS_SECRET_ACCESS_KEY" value="none"/>
+    </php>
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>

--- a/src/BatchGetRetriesExhausted.php
+++ b/src/BatchGetRetriesExhausted.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+use RuntimeException;
+
+final class BatchGetRetriesExhausted extends RuntimeException
+{
+    /**
+     * @param list<string> $unresolvedIds
+     */
+    public function __construct(
+        public readonly string $table,
+        public readonly string $repositoryName,
+        public readonly string $readModelClass,
+        public readonly array $unresolvedIds,
+        public readonly int $attempts
+    ) {
+        parent::__construct(sprintf(
+            'Batch get retries exhausted for repository "%s" in table "%s" after %d attempts; unresolved ids: %s.',
+            $repositoryName,
+            $table,
+            $attempts,
+            implode(', ', $unresolvedIds)
+        ));
+    }
+}

--- a/src/DeferredDynamoDbRepository.php
+++ b/src/DeferredDynamoDbRepository.php
@@ -75,8 +75,83 @@ final class DeferredDynamoDbRepository implements FlushableRepository
             return [];
         }
 
+        $criteria = FindByCriteria::from($fields);
+
+        if (!$criteria->hasId) {
+            return $this->matching($this->findAll(), $fields);
+        }
+
+        if ($criteria->impossible || [] === $criteria->ids) {
+            return [];
+        }
+
+        if ($criteria->multiple) {
+            $models = $this->findMany($criteria->ids);
+        } else {
+            $model  = $this->find($criteria->ids[0]);
+            $models = null === $model ? [] : [$model];
+        }
+
+        if ([] === $criteria->remainingFields) {
+            return $models;
+        }
+
+        return $this->matching($models, $criteria->remainingFields);
+    }
+
+    /**
+     * @param list<string> $ids
+     *
+     * @return Identifiable[]
+     */
+    private function findMany(array $ids): array
+    {
+        $removed    = array_fill_keys($this->removed, true);
+        $unresolved = [];
+
+        foreach ($ids as $id) {
+            if (isset($removed[$id])) {
+                continue;
+            }
+
+            if (isset($this->managed[$id])) {
+                continue;
+            }
+
+            if (isset($this->dirty[$id])) {
+                $this->managed[$id] = $this->storage->modelFromPreparedSave($this->dirty[$id]);
+
+                continue;
+            }
+
+            $unresolved[] = $id;
+        }
+
+        foreach ($this->storage->findMany($unresolved) as $model) {
+            $this->managed[$model->getId()] = $model;
+        }
+
+        $models = [];
+
+        foreach ($ids as $id) {
+            if (isset($this->managed[$id]) && !isset($removed[$id])) {
+                $models[] = $this->managed[$id];
+            }
+        }
+
+        return $models;
+    }
+
+    /**
+     * @param Identifiable[]      $models
+     * @param array<string,mixed> $fields
+     *
+     * @return Identifiable[]
+     */
+    private function matching(array $models, array $fields): array
+    {
         return array_values(array_filter(
-            $this->findAll(),
+            $models,
             fn (Identifiable $model): bool => $this->matcher->matches($model, $fields)
         ));
     }

--- a/src/DynamoDbReadModelStorage.php
+++ b/src/DynamoDbReadModelStorage.php
@@ -5,13 +5,29 @@ declare(strict_types=1);
 namespace chrisjenkinson\DynamoDbReadModel;
 
 use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\ValueObject\KeysAndAttributes;
 use Broadway\ReadModel\Identifiable;
 use Broadway\Serializer\Serializer;
 use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedEncodedData;
 use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
+use Closure;
 
 final class DynamoDbReadModelStorage
 {
+    private const BATCH_SIZE = 100;
+
+    private const BATCH_ATTEMPTS = 4;
+
+    private const RETRY_DELAY_CAPS = [25000, 50000, 100000];
+
+    /**
+     * @var Closure(int): void
+     */
+    private readonly Closure $delay;
+
+    /**
+     * @param null|Closure(int): void $delay
+     */
     public function __construct(
         private readonly DynamoDbClient $client,
         private readonly InputBuilder $inputBuilder,
@@ -21,8 +37,12 @@ final class DynamoDbReadModelStorage
         private readonly string $table,
         private readonly string $name,
         private readonly string $class,
-        private readonly ReadModelSnapshotStore $snapshots
+        private readonly ReadModelSnapshotStore $snapshots,
+        ?Closure $delay = null
     ) {
+        $this->delay = $delay ?? static function (int $max): void {
+            usleep(random_int(0, $max));
+        };
     }
 
     public function table(): string
@@ -60,7 +80,8 @@ final class DynamoDbReadModelStorage
         $encodedData  = $this->jsonEncoder->encode($save->serializedData);
         $putItemInput = $this->inputBuilder->buildPutItemInput($this->table, $this->name, $save->id, $encodedData);
 
-        $this->client->putItem($putItemInput)->resolve();
+        $this->client->putItem($putItemInput)
+            ->resolve();
         $this->snapshots->remember($snapshot);
     }
 
@@ -81,6 +102,79 @@ final class DynamoDbReadModelStorage
         }
 
         return $this->deserializeReadModel($encodedData, $id);
+    }
+
+    /**
+     * @param list<string> $ids
+     *
+     * @return Identifiable[]
+     */
+    public function findMany(array $ids): array
+    {
+        $ids = array_values(array_unique($ids));
+
+        if ([] === $ids) {
+            return [];
+        }
+
+        $modelsById = [];
+
+        foreach (array_chunk($ids, self::BATCH_SIZE) as $chunk) {
+            $input          = $this->inputBuilder->buildBatchGetItemInput($this->table, $this->name, $chunk);
+            $outstandingIds = $chunk;
+
+            for ($attempt = 1; $attempt <= self::BATCH_ATTEMPTS; ++$attempt) {
+                $result        = $this->client->batchGetItem($input);
+                $responseItems = $this->validateResponses($result->getResponses(), $outstandingIds);
+
+                $responseIds = array_map(static fn (array $item): string => $item['Id']->getS() ?? '', $responseItems);
+
+                $unprocessedKeys   = $result->getUnprocessedKeys();
+                $keysAndAttributes = null;
+                $unresolvedIds     = [];
+
+                if ([] !== $unprocessedKeys) {
+                    [$keysAndAttributes, $unresolvedIds] = $this->validateUnprocessedKeys($unprocessedKeys, $outstandingIds);
+                }
+
+                if ([] !== array_intersect($responseIds, $unresolvedIds)) {
+                    throw new UnexpectedEncodedData('BatchGetItem', 'disjoint response and unprocessed ids', [$responseIds, $unresolvedIds]);
+                }
+
+                foreach ($responseItems as $item) {
+                    $model                       = $this->modelFromBatchItem($item);
+                    $modelsById[$model->getId()] = $model;
+                }
+
+                if ([] === $unprocessedKeys) {
+                    break;
+                }
+
+                if (self::BATCH_ATTEMPTS === $attempt) {
+                    throw new BatchGetRetriesExhausted(
+                        $this->table,
+                        $this->name,
+                        $this->class,
+                        array_values(array_intersect($chunk, $unresolvedIds)),
+                        $attempt
+                    );
+                }
+
+                ($this->delay)(self::RETRY_DELAY_CAPS[$attempt - 1]);
+                $input          = $this->inputBuilder->buildBatchGetItemRetryInput($this->table, $keysAndAttributes);
+                $outstandingIds = $unresolvedIds;
+            }
+        }
+
+        $models = [];
+
+        foreach ($ids as $id) {
+            if (isset($modelsById[$id])) {
+                $models[] = $modelsById[$id];
+            }
+        }
+
+        return $models;
     }
 
     /**
@@ -117,7 +211,8 @@ final class DynamoDbReadModelStorage
 
     public function remove(string $id): void
     {
-        $this->client->deleteItem($this->inputBuilder->buildDeleteItemInput($this->table, $this->name, $id))->resolve();
+        $this->client->deleteItem($this->inputBuilder->buildDeleteItemInput($this->table, $this->name, $id))
+            ->resolve();
         $this->snapshots->forget($this->table, $this->name, $this->class, $id);
     }
 
@@ -129,6 +224,116 @@ final class DynamoDbReadModelStorage
     private function deserializeReadModel(string $encodedData, string $observedId): Identifiable
     {
         return $this->deserializeSerializedReadModel($this->jsonDecoder->decode($encodedData), $observedId, true);
+    }
+
+    /**
+     * @param array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> $item
+     */
+    private function modelFromBatchItem(array $item): Identifiable
+    {
+        $observedId = ($item['Id'] ?? null)?->getS();
+
+        if (!is_string($observedId)) {
+            throw new UnexpectedEncodedData('Id', 'string', $observedId);
+        }
+
+        $encodedData = ($item['Data'] ?? null)?->getS();
+
+        if (!is_string($encodedData)) {
+            throw new UnexpectedEncodedData('Data', 'string', $encodedData);
+        }
+
+        return $this->deserializeReadModel($encodedData, $observedId);
+    }
+
+    /**
+     * @param array<string, array<int, array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue>>> $responses
+     * @param list<string>                                                                              $outstandingIds
+     *
+     * @return array<int, array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue>>
+     */
+    private function validateResponses(array $responses, array $outstandingIds): array
+    {
+        if ([] !== $responses && [$this->table] !== array_keys($responses)) {
+            throw new UnexpectedEncodedData('Responses', sprintf('only table %s', $this->table), $responses);
+        }
+
+        $items          = $responses[$this->table] ?? [];
+        $outstandingSet = array_fill_keys($outstandingIds, true);
+        $observedIds    = [];
+
+        foreach ($items as $item) {
+            $id = ($item['Id'] ?? null)?->getS();
+
+            if (!is_string($id)) {
+                throw new UnexpectedEncodedData('Id', 'string', $id);
+            }
+
+            if ('' === $id || !isset($outstandingSet[$id]) || isset($observedIds[$id])) {
+                throw new UnexpectedEncodedData('Id', 'a unique non-empty id outstanding in the current attempt', $id);
+            }
+
+            $encodedData = ($item['Data'] ?? null)?->getS();
+
+            if (!is_string($encodedData)) {
+                throw new UnexpectedEncodedData('Data', 'string', $encodedData);
+            }
+
+            $observedIds[$id] = true;
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param array<string, KeysAndAttributes> $unprocessedKeys
+     * @param list<string>                     $outstandingIds
+     *
+     * @return array{KeysAndAttributes, list<string>}
+     */
+    private function validateUnprocessedKeys(array $unprocessedKeys, array $outstandingIds): array
+    {
+        if ([$this->table] !== array_keys($unprocessedKeys)) {
+            throw new UnexpectedEncodedData('UnprocessedKeys', sprintf('only table %s', $this->table), $unprocessedKeys);
+        }
+
+        $keysAndAttributes = $unprocessedKeys[$this->table];
+        $keys              = $keysAndAttributes->getKeys();
+
+        if ([] === $keys) {
+            throw new UnexpectedEncodedData('UnprocessedKeys', 'at least one key', $keys);
+        }
+
+        $outstandingSet = array_fill_keys($outstandingIds, true);
+        $observedIds    = [];
+        $unresolvedIds  = [];
+
+        foreach ($keys as $key) {
+            $name = ($key['Name'] ?? null)?->getS();
+
+            if (!is_string($name)) {
+                throw new UnexpectedEncodedData('UnprocessedKeys.Name', 'string', $name);
+            }
+
+            if ($this->name !== $name) {
+                throw new UnexpectedEncodedData('UnprocessedKeys.Name', $this->name, $name);
+            }
+
+            $id = ($key['Id'] ?? null)?->getS();
+
+            if (!is_string($id)) {
+                throw new UnexpectedEncodedData('UnprocessedKeys.Id', 'string', $id);
+            }
+
+            if ('' === $id || !isset($outstandingSet[$id]) || isset($observedIds[$id])) {
+                throw new UnexpectedEncodedData('UnprocessedKeys.Id', 'a unique non-empty id outstanding in the current attempt', $id);
+            }
+
+            $observedIds[$id] = true;
+            $unresolvedIds[]  = $id;
+        }
+
+        return [$keysAndAttributes, $unresolvedIds];
     }
 
     /**

--- a/src/DynamoDbRepository.php
+++ b/src/DynamoDbRepository.php
@@ -34,8 +34,40 @@ final class DynamoDbRepository implements Repository
             return [];
         }
 
+        $criteria = FindByCriteria::from($fields);
+
+        if (!$criteria->hasId) {
+            return $this->matching($this->findAll(), $fields);
+        }
+
+        if ($criteria->impossible || [] === $criteria->ids) {
+            return [];
+        }
+
+        if ($criteria->multiple) {
+            $models = $this->storage->findMany($criteria->ids);
+        } else {
+            $model  = $this->storage->find($criteria->ids[0]);
+            $models = null === $model ? [] : [$model];
+        }
+
+        if ([] === $criteria->remainingFields) {
+            return $models;
+        }
+
+        return $this->matching($models, $criteria->remainingFields);
+    }
+
+    /**
+     * @param Identifiable[]      $models
+     * @param array<string,mixed> $fields
+     *
+     * @return Identifiable[]
+     */
+    private function matching(array $models, array $fields): array
+    {
         $items = array_filter(
-            $this->findAll(),
+            $models,
             fn (Identifiable $model): bool => $this->matcher->matches($model, $fields)
         );
 

--- a/src/DynamoDbTableManager.php
+++ b/src/DynamoDbTableManager.php
@@ -31,6 +31,7 @@ final class DynamoDbTableManager implements TableManagerInterface
     {
         $this->client->createTable($this->inputBuilder->buildCreateTableInput($this->table));
 
-        $this->client->tableExists($this->inputBuilder->buildDescribeTableInput($this->table))->wait();
+        $this->client->tableExists($this->inputBuilder->buildDescribeTableInput($this->table))
+            ->wait();
     }
 }

--- a/src/Exception/InvalidIdCriterion.php
+++ b/src/Exception/InvalidIdCriterion.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Exception;
+
+final class InvalidIdCriterion extends \InvalidArgumentException
+{
+    private function __construct(
+        public readonly string $reason,
+        public readonly ?int $index,
+        public readonly string $actualType,
+        string $message
+    ) {
+        parent::__construct($message);
+    }
+
+    public static function nonList(): self
+    {
+        return new self(
+            'non-list',
+            null,
+            'array',
+            'The ID criterion array must be a list.'
+        );
+    }
+
+    public static function invalidEntry(int $index, mixed $value): self
+    {
+        $actualType = get_debug_type($value);
+
+        return new self(
+            'invalid-entry',
+            $index,
+            $actualType,
+            sprintf('The ID criterion entry at index %d must be a non-empty string; got %s.', $index, $actualType)
+        );
+    }
+}

--- a/src/FindByCriteria.php
+++ b/src/FindByCriteria.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+use chrisjenkinson\DynamoDbReadModel\Exception\InvalidIdCriterion;
+
+final class FindByCriteria
+{
+    /**
+     * @param list<string>        $ids
+     * @param array<string,mixed> $remainingFields
+     */
+    private function __construct(
+        public readonly bool $hasId,
+        public readonly bool $multiple,
+        public readonly bool $impossible,
+        public readonly array $ids,
+        public readonly array $remainingFields
+    ) {
+    }
+
+    /**
+     * @param array<string,mixed> $fields
+     */
+    public static function from(array $fields): self
+    {
+        if (!array_key_exists('id', $fields)) {
+            return new self(false, false, false, [], $fields);
+        }
+
+        $criterion       = $fields['id'];
+        $remainingFields = $fields;
+        unset($remainingFields['id']);
+
+        if (is_string($criterion) && '' !== $criterion) {
+            return new self(true, false, false, [$criterion], $remainingFields);
+        }
+
+        if (is_array($criterion)) {
+            if (!array_is_list($criterion)) {
+                throw InvalidIdCriterion::nonList();
+            }
+
+            $ids     = [];
+            $seenIds = [];
+
+            foreach ($criterion as $index => $id) {
+                if (!is_string($id) || '' === $id) {
+                    throw InvalidIdCriterion::invalidEntry($index, $id);
+                }
+
+                if (isset($seenIds[$id])) {
+                    continue;
+                }
+
+                $seenIds[$id] = true;
+                $ids[]        = $id;
+            }
+
+            return new self(true, true, false, $ids, $remainingFields);
+        }
+
+        return new self(true, false, true, [], $remainingFields);
+    }
+}

--- a/src/InputBuilder.php
+++ b/src/InputBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace chrisjenkinson\DynamoDbReadModel;
 
+use AsyncAws\DynamoDb\Input\BatchGetItemInput;
 use AsyncAws\DynamoDb\Input\CreateTableInput;
 use AsyncAws\DynamoDb\Input\DeleteItemInput;
 use AsyncAws\DynamoDb\Input\DeleteTableInput;
@@ -13,6 +14,7 @@ use AsyncAws\DynamoDb\Input\PutItemInput;
 use AsyncAws\DynamoDb\Input\QueryInput;
 use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use AsyncAws\DynamoDb\ValueObject\KeysAndAttributes;
 use AsyncAws\DynamoDb\ValueObject\KeySchemaElement;
 
 final class InputBuilder
@@ -92,6 +94,41 @@ final class InputBuilder
             'ProjectionExpression'     => '#Data',
             'ExpressionAttributeNames' => [
                 '#Data' => 'Data',
+            ],
+        ]);
+    }
+
+    /**
+     * @param list<string> $ids
+     */
+    public function buildBatchGetItemInput(string $table, string $name, array $ids): BatchGetItemInput
+    {
+        return new BatchGetItemInput([
+            'RequestItems' => [
+                $table => new KeysAndAttributes([
+                    'Keys' => array_map(static fn (string $id): array => [
+                        'Name' => new AttributeValue([
+                            'S' => $name,
+                        ]),
+                        'Id' => new AttributeValue([
+                            'S' => $id,
+                        ]),
+                    ], $ids),
+                    'ProjectionExpression'     => '#Id, #Data',
+                    'ExpressionAttributeNames' => [
+                        '#Id'   => 'Id',
+                        '#Data' => 'Data',
+                    ],
+                ]),
+            ],
+        ]);
+    }
+
+    public function buildBatchGetItemRetryInput(string $table, KeysAndAttributes $keysAndAttributes): BatchGetItemInput
+    {
+        return new BatchGetItemInput([
+            'RequestItems' => [
+                $table => $keysAndAttributes,
             ],
         ]);
     }

--- a/tests/DeferredDynamoDbRepositoryIntegrationTest.php
+++ b/tests/DeferredDynamoDbRepositoryIntegrationTest.php
@@ -73,6 +73,27 @@ final class DeferredDynamoDbRepositoryIntegrationTest extends TestCase
         ]));
     }
 
+    public function test_deferred_id_list_lookup_merges_staged_and_persisted_models_in_requested_order_before_filtering(): void
+    {
+        $factory = $this->createFactory();
+
+        $persistedMatching = new RepositoryTestReadModel('persisted-matching', 'persisted-matching', 'matched', []);
+        $persistedOther    = new RepositoryTestReadModel('persisted-other', 'persisted-other', 'other', []);
+        $dirty             = new RepositoryTestReadModel('dirty', 'dirty', 'matched', []);
+
+        $immediate = $factory->create(self::REPOSITORY_NAME, RepositoryTestReadModel::class);
+        $immediate->save($persistedMatching);
+        $immediate->save($persistedOther);
+
+        $deferred = $factory->createDeferred(self::REPOSITORY_NAME, RepositoryTestReadModel::class);
+        $deferred->save($dirty);
+
+        self::assertEquals([$persistedMatching, $dirty], $deferred->findBy([
+            'id'  => ['persisted-other', 'persisted-matching', 'dirty'],
+            'foo' => 'matched',
+        ]));
+    }
+
     public function test_deferred_queries_reject_rows_whose_physical_id_does_not_match_the_payload_id(): void
     {
         $factory = $this->createFactory();
@@ -96,20 +117,21 @@ final class DeferredDynamoDbRepositoryIntegrationTest extends TestCase
 
     private function putSerializedReadModel(string $physicalId, RepositoryTestReadModel $model): void
     {
-        $this->createClient()->putItem([
-            'TableName' => self::TABLE_NAME,
-            'Item'      => [
-                'Name' => new AttributeValue([
-                    'S' => self::REPOSITORY_NAME,
-                ]),
-                'Id' => new AttributeValue([
-                    'S' => $physicalId,
-                ]),
-                'Data' => new AttributeValue([
-                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
-                ]),
-            ],
-        ])->resolve();
+        $this->createClient()
+            ->putItem([
+                'TableName' => self::TABLE_NAME,
+                'Item'      => [
+                    'Name' => new AttributeValue([
+                        'S' => self::REPOSITORY_NAME,
+                    ]),
+                    'Id' => new AttributeValue([
+                        'S' => $physicalId,
+                    ]),
+                    'Data' => new AttributeValue([
+                        'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                    ]),
+                ],
+            ])->resolve();
     }
 
     private function createClient(): DynamoDbClient

--- a/tests/DeferredDynamoDbRepositoryIntegrationTest.php
+++ b/tests/DeferredDynamoDbRepositoryIntegrationTest.php
@@ -137,13 +137,13 @@ final class DeferredDynamoDbRepositoryIntegrationTest extends TestCase
     private function createClient(): DynamoDbClient
     {
         return new DynamoDbClient(Configuration::create([
-            'endpoint'        => $this->required_environment_variable('DYNAMODB_ENDPOINT'),
-            'accessKeyId'     => $this->required_environment_variable('AWS_ACCESS_KEY_ID'),
-            'accessKeySecret' => $this->required_environment_variable('AWS_SECRET_ACCESS_KEY'),
+            'endpoint'        => $this->requiredEnvironmentVariable('DYNAMODB_ENDPOINT'),
+            'accessKeyId'     => $this->requiredEnvironmentVariable('AWS_ACCESS_KEY_ID'),
+            'accessKeySecret' => $this->requiredEnvironmentVariable('AWS_SECRET_ACCESS_KEY'),
         ]));
     }
 
-    private function required_environment_variable(string $name): string
+    private function requiredEnvironmentVariable(string $name): string
     {
         $value = getenv($name);
 

--- a/tests/DeferredDynamoDbRepositoryIntegrationTest.php
+++ b/tests/DeferredDynamoDbRepositoryIntegrationTest.php
@@ -137,9 +137,20 @@ final class DeferredDynamoDbRepositoryIntegrationTest extends TestCase
     private function createClient(): DynamoDbClient
     {
         return new DynamoDbClient(Configuration::create([
-            'endpoint'        => getenv('DYNAMODB_ENDPOINT') ?: 'http://dynamodb-local:8000',
-            'accessKeyId'     => getenv('AWS_ACCESS_KEY_ID') ?: 'none',
-            'accessKeySecret' => getenv('AWS_SECRET_ACCESS_KEY') ?: 'none',
+            'endpoint'        => $this->required_environment_variable('DYNAMODB_ENDPOINT'),
+            'accessKeyId'     => $this->required_environment_variable('AWS_ACCESS_KEY_ID'),
+            'accessKeySecret' => $this->required_environment_variable('AWS_SECRET_ACCESS_KEY'),
         ]));
+    }
+
+    private function required_environment_variable(string $name): string
+    {
+        $value = getenv($name);
+
+        if (false === $value || '' === $value) {
+            throw new \RuntimeException(sprintf('Required environment variable "%s" is not set.', $name));
+        }
+
+        return $value;
     }
 }

--- a/tests/DeferredDynamoDbRepositoryTest.php
+++ b/tests/DeferredDynamoDbRepositoryTest.php
@@ -7,12 +7,15 @@ namespace chrisjenkinson\DynamoDbReadModel\Tests;
 use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Input\BatchGetItemInput;
 use AsyncAws\DynamoDb\Input\PutItemInput;
+use AsyncAws\DynamoDb\Result\BatchGetItemOutput;
 use AsyncAws\DynamoDb\Result\DeleteItemOutput;
 use AsyncAws\DynamoDb\Result\GetItemOutput;
 use AsyncAws\DynamoDb\Result\PutItemOutput;
 use AsyncAws\DynamoDb\Result\QueryOutput;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use Broadway\ReadModel\Identifiable;
 use Broadway\ReadModel\Repository;
 use Broadway\ReadModel\SerializableReadModel;
 use Broadway\ReadModel\Testing\RepositoryTestReadModel;
@@ -77,7 +80,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     public function test_find_accepts_a_stringable_id(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('getItem');
+        $client->expects($this->never())
+            ->method('getItem');
 
         $repository = $this->createRepository($client);
         $model      = new RepositoryTestReadModel('id', 'name', 'foo', []);
@@ -90,19 +94,23 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     public function test_save_marks_the_model_dirty_without_writing_immediately(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $this->createRepository($client)->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+        $this->createRepository($client)
+            ->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
     }
 
     public function test_save_rejects_a_read_model_for_a_different_repository_class(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
         $this->expectException(UnexpectedReadModel::class);
 
-        $this->createRepository($client)->save(new UnexpectedSerializableReadModel('wrong-class'));
+        $this->createRepository($client)
+            ->save(new UnexpectedSerializableReadModel('wrong-class'));
     }
 
     public function test_flush_persists_dirty_models(): void
@@ -110,7 +118,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $putItemOutput = new PutItemOutput($this->createResponse());
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($putItemOutput);
 
         $repository = $this->createRepository($client);
         $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
@@ -171,7 +181,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     public function test_find_returns_the_saved_snapshot_state_after_the_original_model_is_mutated(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('getItem');
+        $client->expects($this->never())
+            ->method('getItem');
 
         $repository = $this->createMutableRepository($client);
         $model      = new MutableRepositoryTestReadModel('id', 'saved');
@@ -221,7 +232,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     public function test_find_all_preserves_the_identity_mapped_staged_save_snapshot(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor());
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor());
 
         $repository = $this->createMutableRepository($client);
         $repository->save(new MutableRepositoryTestReadModel('id', 'saved'));
@@ -240,15 +253,18 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     public function test_remove_marks_the_model_removed_without_deleting_immediately(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('deleteItem');
+        $client->expects($this->never())
+            ->method('deleteItem');
 
-        $this->createRepository($client)->remove('id');
+        $this->createRepository($client)
+            ->remove('id');
     }
 
     public function test_remove_accepts_a_stringable_id(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('getItem');
+        $client->expects($this->never())
+            ->method('getItem');
 
         $repository = $this->createRepository($client);
         $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
@@ -260,7 +276,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     public function test_removed_items_are_hidden_from_find_until_saved_again(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('getItem');
+        $client->expects($this->never())
+            ->method('getItem');
 
         $repository = $this->createRepository($client);
         $repository->remove('id');
@@ -273,7 +290,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $deleteItemOutput = new DeleteItemOutput($this->createResponse());
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('deleteItem')->willReturn($deleteItemOutput);
+        $client->expects($this->once())
+            ->method('deleteItem')
+            ->willReturn($deleteItemOutput);
 
         $repository = $this->createRepository($client);
         $repository->remove('id');
@@ -310,8 +329,11 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $putItemOutput = new PutItemOutput($this->createResponse());
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('deleteItem');
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->never())
+            ->method('deleteItem');
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($putItemOutput);
 
         $repository = $this->createRepository($client);
         $repository->remove('id');
@@ -325,8 +347,11 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $deleteItemOutput = new DeleteItemOutput($this->createResponse());
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('putItem');
-        $client->expects($this->once())->method('deleteItem')->willReturn($deleteItemOutput);
+        $client->expects($this->never())
+            ->method('putItem');
+        $client->expects($this->once())
+            ->method('deleteItem')
+            ->willReturn($deleteItemOutput);
 
         $repository = $this->createRepository($client);
         $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
@@ -353,8 +378,10 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     public function test_clear_discards_managed_dirty_and_removed_state(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('putItem');
-        $client->expects($this->never())->method('deleteItem');
+        $client->expects($this->never())
+            ->method('putItem');
+        $client->expects($this->never())
+            ->method('deleteItem');
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('removed', 'name', 'foo', [])));
@@ -375,7 +402,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $dirty     = new RepositoryTestReadModel('dirty', 'dirty', 'foo', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($persisted));
 
         $repository = $this->createRepository($client);
         $repository->remove('persisted');
@@ -390,7 +419,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $kept    = new RepositoryTestReadModel('kept', 'kept', 'foo', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($removed, $kept));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($removed, $kept));
 
         $repository = $this->createRepository($client);
         $repository->remove('removed');
@@ -407,7 +438,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
 
         $this->expectException(UnexpectedReadModel::class);
 
-        $this->createRepository($client)->find('physical-id');
+        $this->createRepository($client)
+            ->find('physical-id');
     }
 
     public function test_find_all_rejects_rows_whose_physical_id_does_not_match_the_payload_id(): void
@@ -419,7 +451,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
 
         $this->expectException(UnexpectedReadModel::class);
 
-        $this->createRepository($client)->findAll();
+        $this->createRepository($client)
+            ->findAll();
     }
 
     public function test_find_all_preserves_the_identity_mapped_model_when_persisted_state_is_reloaded(): void
@@ -428,7 +461,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $second = new RepositoryTestReadModel('id', 'second', 'foo', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($second));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($second));
 
         $repository = $this->createRepository($client);
         $repository->save($first);
@@ -442,8 +477,12 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $second = new RepositoryTestReadModel('id', 'second', 'foo', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('getItem')->willReturn($this->getItemOutputFor($first));
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($second));
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor($first));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($second));
 
         $repository = $this->createRepository($client);
         $model      = $repository->find('id');
@@ -457,7 +496,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $dirty     = new RepositoryTestReadModel('dirty', 'dirty', 'matched', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($persisted));
 
         $repository = $this->createRepository($client);
         $repository->save($dirty);
@@ -473,7 +514,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $dirty     = new RepositoryTestReadModel('dirty', 'dirty', 'unmatched', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($persisted));
 
         $repository = $this->createRepository($client);
         $repository->save($dirty);
@@ -489,7 +532,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $dirty     = new RepositoryTestReadModel('id', 'name', 'unmatched', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($persisted));
 
         $repository = $this->createRepository($client);
         $repository->save($dirty);
@@ -505,7 +550,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $dirty     = new RepositoryTestReadModel('id', 'name', 'matched', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($persisted));
 
         $repository = $this->createRepository($client);
         $repository->save($dirty);
@@ -520,7 +567,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $persisted = new RepositoryTestReadModel('id', 'name', 'matched', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($persisted));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($persisted));
 
         $repository = $this->createRepository($client);
         $repository->remove('id');
@@ -539,9 +588,10 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
 
         $this->expectException(UnexpectedReadModel::class);
 
-        $this->createRepository($client)->findBy([
-            'foo' => 'matched',
-        ]);
+        $this->createRepository($client)
+            ->findBy([
+                'foo' => 'matched',
+            ]);
     }
 
     public function test_find_by_filters_array_getters_by_contained_values(): void
@@ -550,7 +600,9 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $notMatching = new RepositoryTestReadModel('not-matching', 'not-matching', 'foo', ['other']);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($matching, $notMatching));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($matching, $notMatching));
 
         $repository = $this->createRepository($client);
 
@@ -565,13 +617,254 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $notMatching = new RepositoryTestReadModel('not-matching', 'other', 'foo', []);
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('query')->willReturn($this->queryOutputFor($matching, $notMatching));
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($matching, $notMatching));
 
         $repository = $this->createRepository($client);
 
         self::assertEquals([$matching], $repository->findBy([
             'name' => 'matched',
         ]));
+    }
+
+    public function test_find_by_scalar_id_uses_the_existing_local_first_find_path(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())
+            ->method('getItem');
+        $client->expects($this->never())
+            ->method('batchGetItem');
+        $client->expects($this->never())
+            ->method('query');
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('id', 'saved', 'foo', []));
+
+        $found = $repository->find('id');
+
+        self::assertSame([$found], $repository->findBy([
+            'id' => 'id',
+        ]));
+    }
+
+    public function test_find_by_scalar_id_applies_remaining_predicates_to_the_identity_mapped_model(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn(
+                $this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'matched', []))
+            );
+        $client->expects($this->never())
+            ->method('batchGetItem');
+        $client->expects($this->never())
+            ->method('query');
+
+        $repository = $this->createRepository($client);
+
+        self::assertSame(['id'], $this->modelIds($repository->findBy([
+            'id'  => 'id',
+            'foo' => 'matched',
+        ])));
+        self::assertSame([], $repository->findBy([
+            'id'  => 'id',
+            'foo' => 'other',
+        ]));
+    }
+
+    public function test_find_by_impossible_and_empty_id_criteria_do_not_read_or_materialize_dirty_state(): void
+    {
+        CountingDeserializationsReadModel::$deserializations = 0;
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())
+            ->method('getItem');
+        $client->expects($this->never())
+            ->method('batchGetItem');
+        $client->expects($this->never())
+            ->method('query');
+        $client->expects($this->never())
+            ->method('putItem');
+        $client->expects($this->never())
+            ->method('deleteItem');
+
+        $repository = new DeferredDynamoDbRepository(
+            $this->createStorage($client, CountingDeserializationsReadModel::class),
+            new ReadModelFieldMatcher()
+        );
+        $repository->save(new CountingDeserializationsReadModel('dirty'));
+
+        self::assertSame([], $repository->findBy([]));
+        self::assertSame([], $repository->findBy([
+            'id' => null,
+        ]));
+        self::assertSame([], $repository->findBy([
+            'id' => [],
+        ]));
+        self::assertSame(0, CountingDeserializationsReadModel::$deserializations);
+    }
+
+    public function test_find_by_id_list_merges_local_and_persisted_models_in_unique_requested_order(): void
+    {
+        $managed = new RepositoryTestReadModel('managed', 'managed', 'matched', []);
+        $fetched = new RepositoryTestReadModel('fetched', 'fetched', 'matched', []);
+        $keys    = [];
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('getItem')
+            ->willReturn($this->getItemOutputFor($managed));
+        $client->expects($this->never())
+            ->method('query');
+        $client->expects($this->never())
+            ->method('putItem');
+        $client->expects($this->never())
+            ->method('deleteItem');
+        $client->expects($this->once())
+            ->method('batchGetItem')
+            ->willReturnCallback(function (BatchGetItemInput $input) use (&$keys, $fetched): BatchGetItemOutput {
+                $keys = array_map(
+                    static fn (array $key): ?string => $key['Id']->getS(),
+                    $input->getRequestItems()['table']
+                        ->getKeys()
+                );
+
+                return $this->batchGetOutputFor($fetched);
+            });
+
+        $repository = $this->createRepository($client);
+        $managed    = $repository->find('managed');
+        $repository->save(new RepositoryTestReadModel('dirty', 'dirty', 'matched', []));
+        $dirty = $repository->find('dirty');
+        $repository->remove('removed');
+
+        $models = $repository->findBy([
+            'id' => ['fetched', 'removed', 'dirty', 'managed', 'missing', 'fetched'],
+        ]);
+
+        self::assertSame(['fetched', 'missing'], $keys);
+        self::assertSame(['fetched', 'dirty', 'managed'], $this->modelIds($models));
+        self::assertSame($dirty, $models[1]);
+        self::assertSame($managed, $models[2]);
+    }
+
+    public function test_find_by_id_list_materializes_staged_saves_locally_from_the_saved_snapshot(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())
+            ->method('getItem');
+        $client->expects($this->never())
+            ->method('batchGetItem');
+        $client->expects($this->never())
+            ->method('query');
+        $client->expects($this->never())
+            ->method('putItem');
+        $client->expects($this->never())
+            ->method('deleteItem');
+
+        $repository = $this->createMutableRepository($client);
+        $original   = new MutableRepositoryTestReadModel('dirty', 'saved');
+        $repository->save($original);
+        $original->rename('mutated');
+
+        $models = $repository->findBy([
+            'id' => ['dirty'],
+        ]);
+
+        self::assertCount(1, $models);
+        self::assertInstanceOf(MutableRepositoryTestReadModel::class, $models[0]);
+        self::assertSame('saved', $models[0]->getName());
+        self::assertSame($models[0], $repository->find('dirty'));
+    }
+
+    public function test_find_by_id_list_applies_remaining_predicates_after_merging_local_and_persistent_models(): void
+    {
+        $persisted = new RepositoryTestReadModel('persisted', 'persisted', 'matched', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())
+            ->method('getItem');
+        $client->expects($this->never())
+            ->method('query');
+        $client->expects($this->never())
+            ->method('putItem');
+        $client->expects($this->never())
+            ->method('deleteItem');
+        $client->expects($this->once())
+            ->method('batchGetItem')
+            ->willReturn($this->batchGetOutputFor($persisted));
+
+        $repository = $this->createRepository($client);
+        $repository->save(new RepositoryTestReadModel('dirty-match', 'dirty-match', 'matched', []));
+        $repository->save(new RepositoryTestReadModel('dirty-other', 'dirty-other', 'other', []));
+
+        self::assertSame(['dirty-match', 'persisted'], $this->modelIds($repository->findBy([
+            'id'  => ['dirty-match', 'dirty-other', 'persisted'],
+            'foo' => 'matched',
+        ])));
+    }
+
+    public function test_find_by_id_list_identity_maps_fetched_models(): void
+    {
+        $persisted = new RepositoryTestReadModel('persisted', 'persisted', 'matched', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())
+            ->method('getItem');
+        $client->expects($this->never())
+            ->method('query');
+        $client->expects($this->never())
+            ->method('putItem');
+        $client->expects($this->never())
+            ->method('deleteItem');
+        $client->expects($this->once())
+            ->method('batchGetItem')
+            ->willReturn($this->batchGetOutputFor($persisted));
+
+        $repository = $this->createRepository($client);
+        $found      = $repository->findBy([
+            'id' => ['persisted'],
+        ])[0];
+
+        self::assertSame($found, $repository->find('persisted'));
+    }
+
+    /**
+     * @dataProvider queryCriteriaWithoutExactLowercaseId
+     *
+     * @param array<string, mixed> $criteria
+     */
+    public function test_find_by_without_an_exact_lowercase_id_preserves_query_semantics(array $criteria): void
+    {
+        $model = new RepositoryTestReadModel('id', 'name', 'matched', []);
+
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->never())
+            ->method('getItem');
+        $client->expects($this->never())
+            ->method('batchGetItem');
+        $client->expects($this->once())
+            ->method('query')
+            ->willReturn($this->queryOutputFor($model));
+
+        self::assertSame(['id'], $this->modelIds($this->createRepository($client)->findBy($criteria)));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public function queryCriteriaWithoutExactLowercaseId(): iterable
+    {
+        yield 'ordinary field' => [[
+            'foo' => 'matched',
+        ]];
+        yield 'legacy Id' => [[
+            'Id' => 'id',
+        ]];
+        yield 'legacy ID' => [[
+            'ID' => 'id',
+        ]];
     }
 
     public function test_failed_flush_preserves_pending_dirty_state_for_retry(): void
@@ -658,7 +951,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $client->expects($this->exactly(4))
             ->method('putItem')
             ->willReturnCallback(function ($input) use (&$attemptedIds): PutItemOutput {
-                $id             = $input->getItem()['Id']->getS();
+                $id = $input->getItem()['Id']
+                    ->getS();
                 $attemptedIds[] = $id;
 
                 if ('second' === $id && 2 === count($attemptedIds)) {
@@ -728,7 +1022,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $client->expects($this->exactly(4))
             ->method('deleteItem')
             ->willReturnCallback(function ($input) use (&$attemptedRemoves): DeleteItemOutput {
-                $id                 = $input->getKey()['Id']->getS();
+                $id = $input->getKey()['Id']
+                    ->getS();
                 $attemptedRemoves[] = $id;
 
                 if ('second' === $id && 2 === count($attemptedRemoves)) {
@@ -820,11 +1115,12 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     private function getItemOutputFor(RepositoryTestReadModel $model): GetItemOutput
     {
         $output = $this->createStub(GetItemOutput::class);
-        $output->method('getItem')->willReturn([
-            'Data' => new AttributeValue([
-                'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
-            ]),
-        ]);
+        $output->method('getItem')
+            ->willReturn([
+                'Data' => new AttributeValue([
+                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                ]),
+            ]);
 
         return $output;
     }
@@ -832,7 +1128,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     private function queryOutputFor(RepositoryTestReadModel ...$models): QueryOutput
     {
         $output = $this->createStub(QueryOutput::class);
-        $output->method('getCount')->willReturn(count($models));
+        $output->method('getCount')
+            ->willReturn(count($models));
 
         $items = array_map(function (RepositoryTestReadModel $model): array {
             return [
@@ -845,7 +1142,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
             ];
         }, $models);
 
-        $output->method('getItems')->willReturn($items);
+        $output->method('getItems')
+            ->willReturn($items);
 
         return $output;
     }
@@ -853,19 +1151,51 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     private function queryOutputForPhysicalId(string $physicalId, RepositoryTestReadModel $model): QueryOutput
     {
         $output = $this->createStub(QueryOutput::class);
-        $output->method('getCount')->willReturn(1);
-        $output->method('getItems')->willReturn([
-            [
-                'Id' => new AttributeValue([
-                    'S' => $physicalId,
-                ]),
-                'Data' => new AttributeValue([
-                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
-                ]),
-            ],
-        ]);
+        $output->method('getCount')
+            ->willReturn(1);
+        $output->method('getItems')
+            ->willReturn([
+                [
+                    'Id' => new AttributeValue([
+                        'S' => $physicalId,
+                    ]),
+                    'Data' => new AttributeValue([
+                        'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                    ]),
+                ],
+            ]);
 
         return $output;
+    }
+
+    private function batchGetOutputFor(RepositoryTestReadModel ...$models): BatchGetItemOutput
+    {
+        $output = $this->createStub(BatchGetItemOutput::class);
+        $output->method('getResponses')
+            ->willReturn([] === $models ? [] : [
+                'table' => array_map(fn (RepositoryTestReadModel $model): array => [
+                    'Id' => new AttributeValue([
+                        'S' => $model->getId(),
+                    ]),
+                    'Data' => new AttributeValue([
+                        'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                    ]),
+                ], $models),
+            ]);
+        $output->method('getUnprocessedKeys')
+            ->willReturn([]);
+
+        return $output;
+    }
+
+    /**
+     * @param Identifiable[] $models
+     *
+     * @return list<string>
+     */
+    private function modelIds(array $models): array
+    {
+        return array_map(static fn (Identifiable $model): string => $model->getId(), $models);
     }
 
     private function createResponse(): Response
@@ -880,7 +1210,8 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
      */
     private function decodePutItemPayload(PutItemInput $input): array
     {
-        $data = $input->getItem()['Data']->getS();
+        $data = $input->getItem()['Data']
+            ->getS();
         self::assertIsString($data);
 
         return json_decode($data, true, flags: JSON_THROW_ON_ERROR);
@@ -942,5 +1273,40 @@ final class MutableRepositoryTestReadModel implements SerializableReadModel
     public static function deserialize(array $data): self
     {
         return new self($data['id'], $data['name']);
+    }
+}
+
+final class CountingDeserializationsReadModel implements SerializableReadModel
+{
+    public static int $deserializations = 0;
+
+    public function __construct(
+        private readonly string $id
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return array{id: string}
+     */
+    public function serialize(): array
+    {
+        return [
+            'id' => $this->id,
+        ];
+    }
+
+    /**
+     * @param array{id: string} $data
+     */
+    public static function deserialize(array $data): self
+    {
+        ++self::$deserializations;
+
+        return new self($data['id']);
     }
 }

--- a/tests/DynamoDbReadModelStorageBatchGetIntegrationTest.php
+++ b/tests/DynamoDbReadModelStorageBatchGetIntegrationTest.php
@@ -30,9 +30,9 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
     protected function setUp(): void
     {
         $this->client = new DynamoDbClient(Configuration::create([
-            'endpoint'        => getenv('DYNAMODB_ENDPOINT') ?: 'http://127.0.0.1:8000',
-            'accessKeyId'     => 'none',
-            'accessKeySecret' => 'none',
+            'endpoint'        => $this->required_environment_variable('DYNAMODB_ENDPOINT'),
+            'accessKeyId'     => $this->required_environment_variable('AWS_ACCESS_KEY_ID'),
+            'accessKeySecret' => $this->required_environment_variable('AWS_SECRET_ACCESS_KEY'),
         ]));
         $manager = new DynamoDbTableManager($this->client, new InputBuilder(), self::TABLE);
         $manager->deleteTable();
@@ -40,14 +40,14 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
         $this->storage = $this->newStorage();
     }
 
-    public function testReturnsRequestedOrderAndOmitsMissingIds(): void
+    public function test_returns_requested_order_and_omits_missing_ids(): void
     {
         $this->saveModels(['one', 'two', 'three']);
 
         self::assertSame(['three', 'one'], $this->modelIds($this->storage->findMany(['three', 'missing', 'one'])));
     }
 
-    public function testReadsAcrossTheOneHundredItemBoundary(): void
+    public function test_reads_across_the_one_hundred_item_boundary(): void
     {
         $ids = array_map(static fn (int $number): string => 'id-' . $number, range(1, 101));
         $this->saveModels($ids);
@@ -55,7 +55,7 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
         self::assertSame($ids, $this->modelIds($this->storage->findMany($ids)));
     }
 
-    public function testRejectsUnexpectedSerializedClass(): void
+    public function test_rejects_unexpected_serialized_class(): void
     {
         UnexpectedSerializableReadModel::$deserializeWasCalled = false;
         $this->putRaw('id', UnexpectedSerializableReadModel::class, 'id');
@@ -68,7 +68,7 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
         }
     }
 
-    public function testRejectsPhysicalAndPayloadIdentifierMismatch(): void
+    public function test_rejects_physical_and_payload_identifier_mismatch(): void
     {
         $this->putRaw('physical', RepositoryTestReadModel::class, 'payload');
         $this->expectException(UnexpectedReadModel::class);
@@ -76,7 +76,7 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
         $this->storage->findMany(['physical']);
     }
 
-    public function testLoadedSnapshotSuppressesAnUnchangedSave(): void
+    public function test_loaded_snapshot_suppresses_an_unchanged_save(): void
     {
         $model = new RepositoryTestReadModel('id', 'name', 'foo', []);
         $this->storage->save($this->storage->prepareSave($model));
@@ -148,5 +148,16 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
             RepositoryTestReadModel::class,
             new ReadModelSnapshotStore()
         );
+    }
+
+    private function required_environment_variable(string $name): string
+    {
+        $value = getenv($name);
+
+        if (false === $value || '' === $value) {
+            throw new \RuntimeException(sprintf('Required environment variable "%s" is not set.', $name));
+        }
+
+        return $value;
     }
 }

--- a/tests/DynamoDbReadModelStorageBatchGetIntegrationTest.php
+++ b/tests/DynamoDbReadModelStorageBatchGetIntegrationTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use AsyncAws\Core\Configuration;
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use Broadway\ReadModel\Identifiable;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbReadModelStorage;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbTableManager;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
+use chrisjenkinson\DynamoDbReadModel\InputBuilder;
+use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
+use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
+use PHPUnit\Framework\TestCase;
+
+final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
+{
+    private const TABLE = 'batch-get-storage-test';
+
+    private DynamoDbClient $client;
+
+    private DynamoDbReadModelStorage $storage;
+
+    protected function setUp(): void
+    {
+        $this->client = new DynamoDbClient(Configuration::create([
+            'endpoint'        => getenv('DYNAMODB_ENDPOINT') ?: 'http://127.0.0.1:8000',
+            'accessKeyId'     => 'none',
+            'accessKeySecret' => 'none',
+        ]));
+        $manager = new DynamoDbTableManager($this->client, new InputBuilder(), self::TABLE);
+        $manager->deleteTable();
+        $manager->createTable();
+        $this->storage = $this->newStorage();
+    }
+
+    public function testReturnsRequestedOrderAndOmitsMissingIds(): void
+    {
+        $this->saveModels(['one', 'two', 'three']);
+
+        self::assertSame(['three', 'one'], $this->modelIds($this->storage->findMany(['three', 'missing', 'one'])));
+    }
+
+    public function testReadsAcrossTheOneHundredItemBoundary(): void
+    {
+        $ids = array_map(static fn (int $number): string => 'id-' . $number, range(1, 101));
+        $this->saveModels($ids);
+
+        self::assertSame($ids, $this->modelIds($this->storage->findMany($ids)));
+    }
+
+    public function testRejectsUnexpectedSerializedClass(): void
+    {
+        UnexpectedSerializableReadModel::$deserializeWasCalled = false;
+        $this->putRaw('id', UnexpectedSerializableReadModel::class, 'id');
+
+        try {
+            $this->storage->findMany(['id']);
+            self::fail('Expected an unexpected read model exception.');
+        } catch (UnexpectedReadModel) {
+            self::assertFalse(UnexpectedSerializableReadModel::$deserializeWasCalled);
+        }
+    }
+
+    public function testRejectsPhysicalAndPayloadIdentifierMismatch(): void
+    {
+        $this->putRaw('physical', RepositoryTestReadModel::class, 'payload');
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->storage->findMany(['physical']);
+    }
+
+    public function testLoadedSnapshotSuppressesAnUnchangedSave(): void
+    {
+        $model = new RepositoryTestReadModel('id', 'name', 'foo', []);
+        $this->storage->save($this->storage->prepareSave($model));
+        $loaded = $this->storage->findMany(['id'])[0];
+
+        (new DynamoDbTableManager($this->client, new InputBuilder(), self::TABLE))->deleteTable();
+
+        $this->storage->save($this->storage->prepareSave($loaded));
+        self::assertSame('id', $loaded->getId());
+    }
+
+    /**
+     * @param list<string> $ids
+     */
+    private function saveModels(array $ids): void
+    {
+        foreach ($ids as $id) {
+            $model = new RepositoryTestReadModel($id, 'name', 'foo', []);
+            $this->storage->save($this->storage->prepareSave($model));
+        }
+    }
+
+    private function putRaw(string $physicalId, string $class, string $payloadId): void
+    {
+        $this->client->putItem([
+            'TableName' => self::TABLE,
+            'Item'      => [
+                'Name' => new AttributeValue([
+                    'S' => 'repository',
+                ]),
+                'Id' => new AttributeValue([
+                    'S' => $physicalId,
+                ]),
+                'Data' => new AttributeValue([
+                    'S' => json_encode([
+                        'class'   => $class,
+                        'payload' => [
+                            'id'    => $payloadId,
+                            'name'  => 'name',
+                            'foo'   => 'foo',
+                            'array' => [],
+                        ],
+                    ], JSON_THROW_ON_ERROR),
+                ]),
+            ],
+        ])->resolve();
+    }
+
+    /**
+     * @param Identifiable[] $models
+     *
+     * @return list<string>
+     */
+    private function modelIds(array $models): array
+    {
+        return array_map(static fn (Identifiable $model): string => $model->getId(), $models);
+    }
+
+    private function newStorage(): DynamoDbReadModelStorage
+    {
+        return new DynamoDbReadModelStorage(
+            $this->client,
+            new InputBuilder(),
+            new SimpleInterfaceSerializer(),
+            new JsonEncoder(),
+            new JsonDecoder(),
+            self::TABLE,
+            'repository',
+            RepositoryTestReadModel::class,
+            new ReadModelSnapshotStore()
+        );
+    }
+}

--- a/tests/DynamoDbReadModelStorageBatchGetIntegrationTest.php
+++ b/tests/DynamoDbReadModelStorageBatchGetIntegrationTest.php
@@ -30,9 +30,9 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
     protected function setUp(): void
     {
         $this->client = new DynamoDbClient(Configuration::create([
-            'endpoint'        => $this->required_environment_variable('DYNAMODB_ENDPOINT'),
-            'accessKeyId'     => $this->required_environment_variable('AWS_ACCESS_KEY_ID'),
-            'accessKeySecret' => $this->required_environment_variable('AWS_SECRET_ACCESS_KEY'),
+            'endpoint'        => $this->requiredEnvironmentVariable('DYNAMODB_ENDPOINT'),
+            'accessKeyId'     => $this->requiredEnvironmentVariable('AWS_ACCESS_KEY_ID'),
+            'accessKeySecret' => $this->requiredEnvironmentVariable('AWS_SECRET_ACCESS_KEY'),
         ]));
         $manager = new DynamoDbTableManager($this->client, new InputBuilder(), self::TABLE);
         $manager->deleteTable();
@@ -150,7 +150,7 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
         );
     }
 
-    private function required_environment_variable(string $name): string
+    private function requiredEnvironmentVariable(string $name): string
     {
         $value = getenv($name);
 

--- a/tests/DynamoDbReadModelStorageBatchGetTest.php
+++ b/tests/DynamoDbReadModelStorageBatchGetTest.php
@@ -83,40 +83,41 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
      *
      * @param array<string, AttributeValue> $item
      */
-    public function testRejectsMissingOrNonStringIdAndData(array $item): void
+    public function testRejectsMissingOrNonStringIdAndData(array $item, string $message): void
     {
         $this->expectException(UnexpectedEncodedData::class);
+        $this->expectExceptionMessage($message);
 
         $this->storage($this->clientReturning([$item]))->findMany(['id']);
     }
 
     /**
-     * @return iterable<string, array{array<string, AttributeValue>}>
+     * @return iterable<string, array{array<string, AttributeValue>, string}>
      */
     public function invalidBatchItems(): iterable
     {
         yield 'missing Id' => [[
             'Data' => $this->stringAttribute('{}'),
-        ]];
+        ], 'Expected "Id" to be "string", instead got "null".'];
         yield 'non-string Id' => [[
             'Id' => new AttributeValue([
                 'N' => '1',
             ]),
             'Data' => $this->stringAttribute('{}'),
-        ]];
+        ], 'Expected "Id" to be "string", instead got "null".'];
         yield 'empty Id' => [[
             'Id'   => $this->stringAttribute(''),
             'Data' => $this->stringAttribute('{}'),
-        ]];
+        ], 'Expected "Id" to be "a unique non-empty id outstanding in the current attempt", instead got "string".'];
         yield 'missing Data' => [[
             'Id' => $this->stringAttribute('id'),
-        ]];
+        ], 'Expected "Data" to be "string", instead got "null".'];
         yield 'non-string Data' => [[
             'Id'   => $this->stringAttribute('id'),
             'Data' => new AttributeValue([
                 'N' => '1',
             ]),
-        ]];
+        ], 'Expected "Data" to be "string", instead got "null".'];
     }
 
     public function testJsonDecodeFailuresPropagate(): void
@@ -175,6 +176,11 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
     public function testRejectsPhysicalAndPayloadIdMismatch(): void
     {
         $this->expectException(UnexpectedReadModel::class);
+        $this->expectExceptionMessage(sprintf(
+            'Mismatch between data (%s with id payload) and expected class (%s with id physical)',
+            RepositoryTestReadModel::class,
+            RepositoryTestReadModel::class
+        ));
 
         $this->storage($this->clientReturning([$this->item('payload', 'physical')]))->findMany(['physical']);
     }
@@ -349,6 +355,10 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
             })->findMany($ids);
             self::fail('Expected retries to be exhausted.');
         } catch (BatchGetRetriesExhausted $exception) {
+            self::assertSame(
+                'Batch get retries exhausted for repository "repository" in table "table" after 4 attempts; unresolved ids: id-002.',
+                $exception->getMessage()
+            );
             self::assertSame('table', $exception->table);
             self::assertSame('repository', $exception->repositoryName);
             self::assertSame(RepositoryTestReadModel::class, $exception->readModelClass);
@@ -456,6 +466,38 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         yield 'duplicate Id' => [[
             'table' => $this->keys(['one', 'one']),
         ]];
+    }
+
+    public function testMissingUnprocessedNameReportsTheMalformedAttribute(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([], [
+            'table' => $this->rawKeys([[
+                'Id' => $this->stringAttribute('one'),
+            ]]),
+        ]));
+
+        $this->expectException(UnexpectedEncodedData::class);
+        $this->expectExceptionMessage('Expected "UnprocessedKeys.Name" to be "string", instead got "null".');
+
+        $this->storage($client)
+            ->findMany(['one']);
+    }
+
+    public function testMissingUnprocessedIdReportsTheMalformedAttribute(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([], [
+            'table' => $this->rawKeys([[
+                'Name' => $this->stringAttribute('repository'),
+            ]]),
+        ]));
+
+        $this->expectException(UnexpectedEncodedData::class);
+        $this->expectExceptionMessage('Expected "UnprocessedKeys.Id" to be "string", instead got "null".');
+
+        $this->storage($client)
+            ->findMany(['one']);
     }
 
     public function testDelayExceptionsPropagateWithoutAnotherRequest(): void

--- a/tests/DynamoDbReadModelStorageBatchGetTest.php
+++ b/tests/DynamoDbReadModelStorageBatchGetTest.php
@@ -1,0 +1,672 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Input\BatchGetItemInput;
+use AsyncAws\DynamoDb\Result\BatchGetItemOutput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use AsyncAws\DynamoDb\ValueObject\KeysAndAttributes;
+use Broadway\ReadModel\Identifiable;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\BatchGetRetriesExhausted;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbReadModelStorage;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedEncodedData;
+use chrisjenkinson\DynamoDbReadModel\Exception\UnexpectedReadModel;
+use chrisjenkinson\DynamoDbReadModel\InputBuilder;
+use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
+use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshot;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+final class DynamoDbReadModelStorageBatchGetTest extends TestCase
+{
+    public function testEmptyIdsReturnWithoutCallingDynamoDb(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::never())->method('batchGetItem');
+
+        self::assertSame([], $this->storage($client)->findMany([]));
+    }
+
+    public function testUnorderedResponsesAreReturnedInUniqueRequestedOrderAndMissingIdsAreOmitted(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->with(self::callback(function (BatchGetItemInput $input): bool {
+            $keys = $input->getRequestItems()['table']
+                ->getKeys();
+
+            return ['one', 'missing', 'three'] === array_map(static fn (array $key): ?string => $key['Id']->getS(), $keys);
+        }))->willReturn($this->output([
+            $this->item('three'),
+            $this->item('one'),
+        ]));
+
+        $models = $this->storage($client)
+            ->findMany(['one', 'missing', 'three', 'one']);
+
+        self::assertSame(['one', 'three'], array_map(static fn (Identifiable $model): string => $model->getId(), $models));
+    }
+
+    public function testOneHundredIdsUseOneRequest(): void
+    {
+        $ids    = $this->ids(100);
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->with(self::callback(
+            static fn (BatchGetItemInput $input): bool => 100 === count($input->getRequestItems()['table']->getKeys())
+        ))->willReturn($this->output([]));
+
+        self::assertSame([], $this->storage($client)->findMany($ids));
+    }
+
+    public function testOneHundredAndOneIdsUseSequentialRequestsOfOneHundredAndOne(): void
+    {
+        $sizes  = [];
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::exactly(2))->method('batchGetItem')->willReturnCallback(function (BatchGetItemInput $input) use (&$sizes): BatchGetItemOutput {
+            $sizes[] = count($input->getRequestItems()['table']->getKeys());
+
+            return $this->output([]);
+        });
+
+        self::assertSame([], $this->storage($client)->findMany($this->ids(101)));
+        self::assertSame([100, 1], $sizes);
+    }
+
+    /**
+     * @dataProvider invalidBatchItems
+     *
+     * @param array<string, AttributeValue> $item
+     */
+    public function testRejectsMissingOrNonStringIdAndData(array $item): void
+    {
+        $this->expectException(UnexpectedEncodedData::class);
+
+        $this->storage($this->clientReturning([$item]))->findMany(['id']);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, AttributeValue>}>
+     */
+    public function invalidBatchItems(): iterable
+    {
+        yield 'missing Id' => [[
+            'Data' => $this->stringAttribute('{}'),
+        ]];
+        yield 'non-string Id' => [[
+            'Id' => new AttributeValue([
+                'N' => '1',
+            ]),
+            'Data' => $this->stringAttribute('{}'),
+        ]];
+        yield 'empty Id' => [[
+            'Id'   => $this->stringAttribute(''),
+            'Data' => $this->stringAttribute('{}'),
+        ]];
+        yield 'missing Data' => [[
+            'Id' => $this->stringAttribute('id'),
+        ]];
+        yield 'non-string Data' => [[
+            'Id'   => $this->stringAttribute('id'),
+            'Data' => new AttributeValue([
+                'N' => '1',
+            ]),
+        ]];
+    }
+
+    public function testJsonDecodeFailuresPropagate(): void
+    {
+        $this->expectException(JsonException::class);
+
+        $this->storage($this->clientReturning([$this->rawItem('id', '{')]))->findMany(['id']);
+    }
+
+    public function testRejectsUnexpectedSerializedClassBeforeDeserializing(): void
+    {
+        UnexpectedSerializableReadModel::$deserializeWasCalled = false;
+        $item                                                  = $this->rawItem('id', json_encode([
+            'class'   => UnexpectedSerializableReadModel::class,
+            'payload' => [
+                'id' => 'id',
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        try {
+            $this->storage($this->clientReturning([$item]))->findMany(['id']);
+            self::fail('Expected an unexpected read model exception.');
+        } catch (UnexpectedReadModel) {
+            self::assertFalse(UnexpectedSerializableReadModel::$deserializeWasCalled);
+        }
+    }
+
+    public function testRejectsNonIdentifiableDeserializedModel(): void
+    {
+        $item = $this->rawItem('id', json_encode([
+            'class'   => NonIdentifiableSerializableReadModel::class,
+            'payload' => [
+                'id' => 'id',
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->storage($this->clientReturning([$item]), NonIdentifiableSerializableReadModel::class)->findMany(['id']);
+    }
+
+    public function testRejectsDeserializedModelOfWrongClass(): void
+    {
+        $item = $this->rawItem('id', json_encode([
+            'class'   => UnexpectedSerializableReadModel::class,
+            'payload' => [
+                'id' => 'id',
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->storage($this->clientReturning([$item]))->findMany(['id']);
+    }
+
+    public function testRejectsPhysicalAndPayloadIdMismatch(): void
+    {
+        $this->expectException(UnexpectedReadModel::class);
+
+        $this->storage($this->clientReturning([$this->item('payload', 'physical')]))->findMany(['physical']);
+    }
+
+    /**
+     * @dataProvider invalidResponseMaps
+     *
+     * @param array<string, array<int, array<string, AttributeValue>>> $responses
+     */
+    public function testRejectsWrongOrExtraResponseTablesBeforeDeserializing(array $responses): void
+    {
+        $snapshots = new ReadModelSnapshotStore();
+        $client    = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->outputMap($responses));
+
+        $this->expectException(UnexpectedEncodedData::class);
+
+        try {
+            $this->storage($client, snapshots: $snapshots)
+                ->findMany(['one']);
+        } finally {
+            self::assertFalse($this->hasSnapshot($snapshots, 'one'));
+        }
+    }
+
+    /**
+     * @return iterable<string, array{array<string, array<int, array<string, AttributeValue>>>}>
+     */
+    public function invalidResponseMaps(): iterable
+    {
+        yield 'wrong table' => [[
+            'other' => [$this->item('one')],
+        ]];
+        yield 'extra table' => [[
+            'table' => [$this->item('one')],
+            'other' => [],
+        ]];
+    }
+
+    public function testRejectsUnknownResponseIdBeforeDeserializing(): void
+    {
+        $snapshots = new ReadModelSnapshotStore();
+        $this->expectException(UnexpectedEncodedData::class);
+
+        try {
+            $this->storage($this->clientReturning([$this->item('unknown')]), snapshots: $snapshots)->findMany(['one']);
+        } finally {
+            self::assertFalse($this->hasSnapshot($snapshots, 'unknown'));
+        }
+    }
+
+    public function testRejectsDuplicateConflictingResponseIdsBeforeDeserializing(): void
+    {
+        $snapshots = new ReadModelSnapshotStore();
+        $client    = $this->clientReturning([
+            $this->item('one'),
+            $this->item('conflicting-payload', 'one'),
+        ]);
+        $this->expectException(UnexpectedEncodedData::class);
+
+        try {
+            $this->storage($client, snapshots: $snapshots)
+                ->findMany(['one']);
+        } finally {
+            self::assertFalse($this->hasSnapshot($snapshots, 'one'));
+        }
+    }
+
+    public function testRejectsDuplicateResponseIdsBeforeDeserializing(): void
+    {
+        $snapshots = new ReadModelSnapshotStore();
+        $client    = $this->clientReturning([
+            $this->item('one'),
+            $this->item('one'),
+        ]);
+        $this->expectException(UnexpectedEncodedData::class);
+
+        try {
+            $this->storage($client, snapshots: $snapshots)
+                ->findMany(['one']);
+        } finally {
+            self::assertFalse($this->hasSnapshot($snapshots, 'one'));
+        }
+    }
+
+    public function testRejectsResponseAndUnprocessedOverlapBeforeDeserializing(): void
+    {
+        $snapshots = new ReadModelSnapshotStore();
+        $client    = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([$this->item('one')], [
+            'table' => $this->keys(['one']),
+        ]));
+        $this->expectException(UnexpectedEncodedData::class);
+
+        try {
+            $this->storage($client, snapshots: $snapshots)
+                ->findMany(['one']);
+        } finally {
+            self::assertFalse($this->hasSnapshot($snapshots, 'one'));
+        }
+    }
+
+    public function testAccumulatesProcessedResponsesAndRetriesOnlyReturnedKeys(): void
+    {
+        $unprocessed = $this->keys(['two']);
+        $outputs     = [
+            $this->output([$this->item('one')], [
+                'table' => $unprocessed,
+            ]),
+            $this->output([$this->item('two')]),
+        ];
+        $requests = [];
+        $client   = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::exactly(2))->method('batchGetItem')->willReturnCallback(function (BatchGetItemInput $input) use (&$outputs, &$requests): BatchGetItemOutput {
+            $requests[] = $input;
+            self::assertNotEmpty($outputs);
+
+            return array_shift($outputs);
+        });
+        $caps = [];
+
+        $models = $this->storage($client, delay: static function (int $cap) use (&$caps): void {
+            $caps[] = $cap;
+        })->findMany(['one', 'two']);
+
+        self::assertSame(['one', 'two'], array_map(static fn (Identifiable $model): string => $model->getId(), $models));
+        self::assertSame([25000], $caps);
+        self::assertSame($unprocessed, $requests[1]->getRequestItems()['table']);
+    }
+
+    public function testRetryDelayCapsResetForEachChunkAndThereIsNoDelayAfterCompletion(): void
+    {
+        $outputs = [
+            $this->output([], [
+                'table' => $this->keys(['id-001']),
+            ]),
+            $this->output([]),
+            $this->output([], [
+                'table' => $this->keys(['id-101']),
+            ]),
+            $this->output([]),
+        ];
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::exactly(4))->method('batchGetItem')->willReturnCallback(static function () use (&$outputs): BatchGetItemOutput {
+            self::assertNotEmpty($outputs);
+
+            return array_shift($outputs);
+        });
+        $caps = [];
+
+        $this->storage($client, delay: static function (int $cap) use (&$caps): void {
+            $caps[] = $cap;
+        })->findMany($this->ids(101));
+
+        self::assertSame([25000, 25000], $caps);
+    }
+
+    public function testThrowsAfterExactlyFourAttemptsAndDoesNotRequestALaterChunk(): void
+    {
+        $ids         = $this->ids(101);
+        $unprocessed = $this->keys(['id-002']);
+        $output      = $this->output([], [
+            'table' => $unprocessed,
+        ]);
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::exactly(4))->method('batchGetItem')->willReturn($output);
+        $caps = [];
+
+        try {
+            $this->storage($client, delay: static function (int $cap) use (&$caps): void {
+                $caps[] = $cap;
+            })->findMany($ids);
+            self::fail('Expected retries to be exhausted.');
+        } catch (BatchGetRetriesExhausted $exception) {
+            self::assertSame('table', $exception->table);
+            self::assertSame('repository', $exception->repositoryName);
+            self::assertSame(RepositoryTestReadModel::class, $exception->readModelClass);
+            self::assertSame(['id-002'], $exception->unresolvedIds);
+            self::assertSame(4, $exception->attempts);
+            self::assertNull($exception->getPrevious());
+            self::assertSame([25000, 50000, 100000], $caps);
+        }
+    }
+
+    public function testExhaustedIdsUseOriginalChunkOrderRatherThanReturnedKeyOrder(): void
+    {
+        $output = $this->output([], [
+            'table' => $this->keys(['three', 'one']),
+        ]);
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::exactly(4))->method('batchGetItem')->willReturn($output);
+
+        try {
+            $this->storage($client, delay: static function (int $cap): void {
+            })->findMany(['one', 'two', 'three']);
+            self::fail('Expected retries to be exhausted.');
+        } catch (BatchGetRetriesExhausted $exception) {
+            self::assertSame(['one', 'three'], $exception->unresolvedIds);
+        }
+    }
+
+    /**
+     * @dataProvider malformedUnprocessedKeys
+     *
+     * @param array<string, KeysAndAttributes> $unprocessed
+     */
+    public function testRejectsMalformedUnprocessedKeysBeforeDelayOrAnotherRequest(array $unprocessed): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([], $unprocessed));
+        $delayCalled = false;
+
+        $this->expectException(UnexpectedEncodedData::class);
+
+        try {
+            $this->storage($client, delay: static function (int $cap) use (&$delayCalled): void {
+                $delayCalled = true;
+            })->findMany(['one', 'two']);
+        } finally {
+            self::assertFalse($delayCalled);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{array<string, KeysAndAttributes>}>
+     */
+    public function malformedUnprocessedKeys(): iterable
+    {
+        yield 'unknown table' => [[
+            'other' => $this->keys(['one']),
+        ]];
+        yield 'multiple tables' => [[
+            'table' => $this->keys(['one']),
+            'other' => $this->keys(['two']),
+        ]];
+        yield 'configured table with zero keys' => [[
+            'table' => new KeysAndAttributes([
+                'Keys' => [],
+            ]),
+        ]];
+        yield 'missing Name' => [[
+            'table' => $this->rawKeys([[
+                'Id' => $this->stringAttribute('one'),
+            ]]),
+        ]];
+        yield 'non-string Name' => [[
+            'table' => $this->rawKeys([[
+                'Name' => new AttributeValue([
+                    'N' => '1',
+                ]),
+                'Id' => $this->stringAttribute('one'),
+            ]]),
+        ]];
+        yield 'wrong Name' => [[
+            'table' => $this->rawKeys([[
+                'Name' => $this->stringAttribute('other'),
+                'Id'   => $this->stringAttribute('one'),
+            ]]),
+        ]];
+        yield 'missing Id' => [[
+            'table' => $this->rawKeys([[
+                'Name' => $this->stringAttribute('repository'),
+            ]]),
+        ]];
+        yield 'non-string Id' => [[
+            'table' => $this->rawKeys([[
+                'Name' => $this->stringAttribute('repository'),
+                'Id'   => new AttributeValue([
+                    'N' => '1',
+                ]),
+            ]]),
+        ]];
+        yield 'empty Id' => [[
+            'table' => $this->keys(['']),
+        ]];
+        yield 'unknown Id' => [[
+            'table' => $this->keys(['unknown']),
+        ]];
+        yield 'duplicate Id' => [[
+            'table' => $this->keys(['one', 'one']),
+        ]];
+    }
+
+    public function testDelayExceptionsPropagateWithoutAnotherRequest(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([], [
+            'table' => $this->keys(['one']),
+        ]));
+        $expected = new \RuntimeException('delay failed');
+
+        try {
+            $this->storage($client, delay: static function (int $cap) use ($expected): void {
+                throw $expected;
+            })->findMany(['one']);
+            self::fail('Expected delay failure.');
+        } catch (\RuntimeException $actual) {
+            self::assertSame($expected, $actual);
+        }
+    }
+
+    public function testSnapshotsFromCompletedChunksRemainAfterALaterChunkExhaustsRetries(): void
+    {
+        $firstChunk  = $this->ids(100);
+        $secondChunk = ['id-101'];
+        $outputs     = [
+            $this->output([$this->item('id-001')]),
+            $this->output([], [
+                'table' => $this->keys($secondChunk),
+            ]),
+            $this->output([], [
+                'table' => $this->keys($secondChunk),
+            ]),
+            $this->output([], [
+                'table' => $this->keys($secondChunk),
+            ]),
+            $this->output([], [
+                'table' => $this->keys($secondChunk),
+            ]),
+        ];
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::exactly(5))->method('batchGetItem')->willReturnCallback(static function () use (&$outputs): BatchGetItemOutput {
+            self::assertNotEmpty($outputs);
+
+            return array_shift($outputs);
+        });
+        $client->expects(self::never())->method('putItem');
+        $storage = $this->storage($client, delay: static function (int $cap): void {
+        });
+
+        try {
+            $storage->findMany([...$firstChunk, ...$secondChunk]);
+            self::fail('Expected retries to be exhausted.');
+        } catch (BatchGetRetriesExhausted) {
+        }
+
+        $model = new RepositoryTestReadModel('id-001', 'name', 'foo', []);
+        $storage->save($storage->prepareSave($model));
+    }
+
+    public function testRetriesValidateAgainstOnlyThePreviousAttemptsOutstandingIds(): void
+    {
+        $outputs = [
+            $this->output([], [
+                'table' => $this->keys(['two']),
+            ]),
+            $this->output([], [
+                'table' => $this->keys(['one']),
+            ]),
+        ];
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::exactly(2))->method('batchGetItem')->willReturnCallback(static function () use (&$outputs): BatchGetItemOutput {
+            self::assertNotEmpty($outputs);
+
+            return array_shift($outputs);
+        });
+        $caps = [];
+        $this->expectException(UnexpectedEncodedData::class);
+
+        try {
+            $this->storage($client, delay: static function (int $cap) use (&$caps): void {
+                $caps[] = $cap;
+            })->findMany(['one', 'two']);
+        } finally {
+            self::assertSame([25000], $caps);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, AttributeValue>> $items
+     */
+    private function clientReturning(array $items): DynamoDbClient
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->output($items));
+
+        return $client;
+    }
+
+    /**
+     * @param array<int, array<string, AttributeValue>> $items
+     * @param array<string, KeysAndAttributes>          $unprocessed
+     */
+    private function output(array $items, array $unprocessed = []): BatchGetItemOutput
+    {
+        return $this->outputMap([] === $items ? [] : [
+            'table' => $items,
+        ], $unprocessed);
+    }
+
+    /**
+     * @param array<string, array<int, array<string, AttributeValue>>> $responses
+     * @param array<string, KeysAndAttributes>                         $unprocessed
+     */
+    private function outputMap(array $responses, array $unprocessed = []): BatchGetItemOutput
+    {
+        $output = $this->createStub(BatchGetItemOutput::class);
+        $output->method('getResponses')
+            ->willReturn($responses);
+        $output->method('getUnprocessedKeys')
+            ->willReturn($unprocessed);
+
+        return $output;
+    }
+
+    private function hasSnapshot(ReadModelSnapshotStore $snapshots, string $id): bool
+    {
+        $model = new RepositoryTestReadModel($id, 'name', 'foo', []);
+
+        return $snapshots->hasSameSnapshot(new ReadModelSnapshot(
+            'table',
+            'repository',
+            RepositoryTestReadModel::class,
+            $id,
+            (new SimpleInterfaceSerializer())->serialize($model)
+        ));
+    }
+
+    /**
+     * @return array<string, AttributeValue>
+     */
+    private function item(string $payloadId, ?string $physicalId = null): array
+    {
+        $model = new RepositoryTestReadModel($payloadId, 'name', 'foo', []);
+
+        return $this->rawItem($physicalId ?? $payloadId, (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)));
+    }
+
+    /**
+     * @return array<string, AttributeValue>
+     */
+    private function rawItem(string $physicalId, string $data): array
+    {
+        return [
+            'Id'   => $this->stringAttribute($physicalId),
+            'Data' => $this->stringAttribute($data),
+        ];
+    }
+
+    private function stringAttribute(string $value): AttributeValue
+    {
+        return new AttributeValue([
+            'S' => $value,
+        ]);
+    }
+
+    /**
+     * @param list<string> $ids
+     */
+    private function keys(array $ids): KeysAndAttributes
+    {
+        return $this->rawKeys(array_map(fn (string $id): array => [
+            'Name' => $this->stringAttribute('repository'),
+            'Id'   => $this->stringAttribute($id),
+        ], $ids));
+    }
+
+    /**
+     * @param array<int, array<string, AttributeValue>> $keys
+     */
+    private function rawKeys(array $keys): KeysAndAttributes
+    {
+        return new KeysAndAttributes([
+            'Keys' => $keys,
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function ids(int $count): array
+    {
+        return array_map(static fn (int $number): string => sprintf('id-%03d', $number), range(1, $count));
+    }
+
+    private function storage(
+        DynamoDbClient $client,
+        string $class = RepositoryTestReadModel::class,
+        ?\Closure $delay = null,
+        ?ReadModelSnapshotStore $snapshots = null
+    ): DynamoDbReadModelStorage {
+        return new DynamoDbReadModelStorage(
+            $client,
+            new InputBuilder(),
+            new SimpleInterfaceSerializer(),
+            new JsonEncoder(),
+            new JsonDecoder(),
+            'table',
+            'repository',
+            $class,
+            $snapshots ?? new ReadModelSnapshotStore(),
+            $delay
+        );
+    }
+}

--- a/tests/DynamoDbReadModelStorageBatchGetTest.php
+++ b/tests/DynamoDbReadModelStorageBatchGetTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
 
 final class DynamoDbReadModelStorageBatchGetTest extends TestCase
 {
-    public function testEmptyIdsReturnWithoutCallingDynamoDb(): void
+    public function test_empty_ids_return_without_calling_dynamo_db(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::never())->method('batchGetItem');
@@ -34,7 +34,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         self::assertSame([], $this->storage($client)->findMany([]));
     }
 
-    public function testUnorderedResponsesAreReturnedInUniqueRequestedOrderAndMissingIdsAreOmitted(): void
+    public function test_unordered_responses_are_returned_in_unique_requested_order_and_missing_ids_are_omitted(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::once())->method('batchGetItem')->with(self::callback(function (BatchGetItemInput $input): bool {
@@ -53,7 +53,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         self::assertSame(['one', 'three'], array_map(static fn (Identifiable $model): string => $model->getId(), $models));
     }
 
-    public function testOneHundredIdsUseOneRequest(): void
+    public function test_one_hundred_ids_use_one_request(): void
     {
         $ids    = $this->ids(100);
         $client = $this->createMock(DynamoDbClient::class);
@@ -64,7 +64,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         self::assertSame([], $this->storage($client)->findMany($ids));
     }
 
-    public function testOneHundredAndOneIdsUseSequentialRequestsOfOneHundredAndOne(): void
+    public function test_one_hundred_and_one_ids_use_sequential_requests_of_one_hundred_and_one(): void
     {
         $sizes  = [];
         $client = $this->createMock(DynamoDbClient::class);
@@ -83,7 +83,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
      *
      * @param array<string, AttributeValue> $item
      */
-    public function testRejectsMissingOrNonStringIdAndData(array $item, string $message): void
+    public function test_rejects_invalid_id_or_data_attributes(array $item, string $message): void
     {
         $this->expectException(UnexpectedEncodedData::class);
         $this->expectExceptionMessage($message);
@@ -120,14 +120,14 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         ], 'Expected "Data" to be "string", instead got "null".'];
     }
 
-    public function testJsonDecodeFailuresPropagate(): void
+    public function test_json_decode_failures_propagate(): void
     {
         $this->expectException(JsonException::class);
 
         $this->storage($this->clientReturning([$this->rawItem('id', '{')]))->findMany(['id']);
     }
 
-    public function testRejectsUnexpectedSerializedClassBeforeDeserializing(): void
+    public function test_rejects_unexpected_serialized_class_before_deserializing(): void
     {
         UnexpectedSerializableReadModel::$deserializeWasCalled = false;
         $item                                                  = $this->rawItem('id', json_encode([
@@ -145,7 +145,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         }
     }
 
-    public function testRejectsNonIdentifiableDeserializedModel(): void
+    public function test_rejects_non_identifiable_deserialized_model(): void
     {
         $item = $this->rawItem('id', json_encode([
             'class'   => NonIdentifiableSerializableReadModel::class,
@@ -159,7 +159,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         $this->storage($this->clientReturning([$item]), NonIdentifiableSerializableReadModel::class)->findMany(['id']);
     }
 
-    public function testRejectsDeserializedModelOfWrongClass(): void
+    public function test_rejects_deserialized_model_of_wrong_class(): void
     {
         $item = $this->rawItem('id', json_encode([
             'class'   => UnexpectedSerializableReadModel::class,
@@ -173,7 +173,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         $this->storage($this->clientReturning([$item]))->findMany(['id']);
     }
 
-    public function testRejectsPhysicalAndPayloadIdMismatch(): void
+    public function test_rejects_physical_and_payload_id_mismatch(): void
     {
         $this->expectException(UnexpectedReadModel::class);
         $this->expectExceptionMessage(sprintf(
@@ -190,7 +190,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
      *
      * @param array<string, array<int, array<string, AttributeValue>>> $responses
      */
-    public function testRejectsWrongOrExtraResponseTablesBeforeDeserializing(array $responses): void
+    public function test_rejects_wrong_or_extra_response_tables_before_deserializing(array $responses): void
     {
         $snapshots = new ReadModelSnapshotStore();
         $client    = $this->createMock(DynamoDbClient::class);
@@ -220,7 +220,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         ]];
     }
 
-    public function testRejectsUnknownResponseIdBeforeDeserializing(): void
+    public function test_rejects_unknown_response_id_before_deserializing(): void
     {
         $snapshots = new ReadModelSnapshotStore();
         $this->expectException(UnexpectedEncodedData::class);
@@ -232,7 +232,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         }
     }
 
-    public function testRejectsDuplicateConflictingResponseIdsBeforeDeserializing(): void
+    public function test_rejects_duplicate_conflicting_response_ids_before_deserializing(): void
     {
         $snapshots = new ReadModelSnapshotStore();
         $client    = $this->clientReturning([
@@ -249,7 +249,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         }
     }
 
-    public function testRejectsDuplicateResponseIdsBeforeDeserializing(): void
+    public function test_rejects_duplicate_response_ids_before_deserializing(): void
     {
         $snapshots = new ReadModelSnapshotStore();
         $client    = $this->clientReturning([
@@ -266,7 +266,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         }
     }
 
-    public function testRejectsResponseAndUnprocessedOverlapBeforeDeserializing(): void
+    public function test_rejects_response_and_unprocessed_overlap_before_deserializing(): void
     {
         $snapshots = new ReadModelSnapshotStore();
         $client    = $this->createMock(DynamoDbClient::class);
@@ -283,7 +283,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         }
     }
 
-    public function testAccumulatesProcessedResponsesAndRetriesOnlyReturnedKeys(): void
+    public function test_accumulates_processed_responses_and_retries_only_returned_keys(): void
     {
         $unprocessed = $this->keys(['two']);
         $outputs     = [
@@ -311,7 +311,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         self::assertSame($unprocessed, $requests[1]->getRequestItems()['table']);
     }
 
-    public function testRetryDelayCapsResetForEachChunkAndThereIsNoDelayAfterCompletion(): void
+    public function test_retry_delay_caps_reset_for_each_chunk_and_there_is_no_delay_after_completion(): void
     {
         $outputs = [
             $this->output([], [
@@ -338,7 +338,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         self::assertSame([25000, 25000], $caps);
     }
 
-    public function testThrowsAfterExactlyFourAttemptsAndDoesNotRequestALaterChunk(): void
+    public function test_throws_after_exactly_four_attempts_and_does_not_request_a_later_chunk(): void
     {
         $ids         = $this->ids(101);
         $unprocessed = $this->keys(['id-002']);
@@ -369,7 +369,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         }
     }
 
-    public function testExhaustedIdsUseOriginalChunkOrderRatherThanReturnedKeyOrder(): void
+    public function test_exhausted_ids_use_original_chunk_order_rather_than_returned_key_order(): void
     {
         $output = $this->output([], [
             'table' => $this->keys(['three', 'one']),
@@ -391,7 +391,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
      *
      * @param array<string, KeysAndAttributes> $unprocessed
      */
-    public function testRejectsMalformedUnprocessedKeysBeforeDelayOrAnotherRequest(array $unprocessed): void
+    public function test_rejects_malformed_unprocessed_keys_before_delay_or_another_request(array $unprocessed): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([], $unprocessed));
@@ -468,7 +468,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         ]];
     }
 
-    public function testMissingUnprocessedNameReportsTheMalformedAttribute(): void
+    public function test_missing_unprocessed_name_reports_the_malformed_attribute(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([], [
@@ -484,7 +484,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
             ->findMany(['one']);
     }
 
-    public function testMissingUnprocessedIdReportsTheMalformedAttribute(): void
+    public function test_missing_unprocessed_id_reports_the_malformed_attribute(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([], [
@@ -500,7 +500,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
             ->findMany(['one']);
     }
 
-    public function testDelayExceptionsPropagateWithoutAnotherRequest(): void
+    public function test_delay_exceptions_propagate_without_another_request(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::once())->method('batchGetItem')->willReturn($this->output([], [
@@ -518,7 +518,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         }
     }
 
-    public function testSnapshotsFromCompletedChunksRemainAfterALaterChunkExhaustsRetries(): void
+    public function test_snapshots_from_completed_chunks_remain_after_a_later_chunk_exhausts_retries(): void
     {
         $firstChunk  = $this->ids(100);
         $secondChunk = ['id-101'];
@@ -557,7 +557,7 @@ final class DynamoDbReadModelStorageBatchGetTest extends TestCase
         $storage->save($storage->prepareSave($model));
     }
 
-    public function testRetriesValidateAgainstOnlyThePreviousAttemptsOutstandingIds(): void
+    public function test_retries_validate_against_only_the_previous_attempts_outstanding_ids(): void
     {
         $outputs = [
             $this->output([], [

--- a/tests/DynamoDbRepositoryIdLookupTest.php
+++ b/tests/DynamoDbRepositoryIdLookupTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
 
 final class DynamoDbRepositoryIdLookupTest extends TestCase
 {
-    public function testScalarLowercaseIdUsesGetItemWithoutQueryingOrBatching(): void
+    public function test_scalar_lowercase_id_uses_get_item_without_querying_or_batching(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::once())->method('getItem')->willReturn($this->getOutput($this->model('one')));
@@ -33,7 +33,7 @@ final class DynamoDbRepositoryIdLookupTest extends TestCase
         ])));
     }
 
-    public function testMissingScalarLowercaseIdReturnsAnEmptyList(): void
+    public function test_missing_scalar_lowercase_id_returns_an_empty_list(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::once())->method('getItem')->willReturn($this->getOutput());
@@ -45,7 +45,7 @@ final class DynamoDbRepositoryIdLookupTest extends TestCase
         ]));
     }
 
-    public function testScalarLowercaseIdAppliesOnlyTheAdditionalPredicates(): void
+    public function test_scalar_lowercase_id_applies_only_the_additional_predicates(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::exactly(2))->method('getItem')->willReturn($this->getOutput($this->model('one', 'foo')));
@@ -63,7 +63,7 @@ final class DynamoDbRepositoryIdLookupTest extends TestCase
         ]));
     }
 
-    public function testIdListUsesBatchGetAndPreservesRequestedOrderWhileOmittingMissingModels(): void
+    public function test_id_list_uses_batch_get_and_preserves_requested_order_while_omitting_missing_models(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::never())->method('getItem');
@@ -78,7 +78,7 @@ final class DynamoDbRepositoryIdLookupTest extends TestCase
         ])));
     }
 
-    public function testIdListPredicatesAreAppliedOnlyToTheBatchLoadedModels(): void
+    public function test_id_list_predicates_are_applied_only_to_the_batch_loaded_models(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::never())->method('getItem');
@@ -94,7 +94,7 @@ final class DynamoDbRepositoryIdLookupTest extends TestCase
         ])));
     }
 
-    public function testImpossibleAndEmptyIdCriteriaReturnWithoutCallingDynamoDb(): void
+    public function test_impossible_and_empty_id_criteria_return_without_calling_dynamo_db(): void
     {
         $client     = $this->clientExpectingNoReads();
         $repository = $this->repository($client);
@@ -108,7 +108,7 @@ final class DynamoDbRepositoryIdLookupTest extends TestCase
         ]));
     }
 
-    public function testMalformedIdListFailsBeforeCallingDynamoDb(): void
+    public function test_malformed_id_list_fails_before_calling_dynamo_db(): void
     {
         $repository = $this->repository($this->clientExpectingNoReads());
         $this->expectException(InvalidIdCriterion::class);
@@ -121,7 +121,7 @@ final class DynamoDbRepositoryIdLookupTest extends TestCase
     /**
      * @dataProvider legacyIdFieldNames
      */
-    public function testNonExactLowercaseIdFieldsRetainQueryAndMatcherSemantics(string $field): void
+    public function test_non_exact_lowercase_id_fields_retain_query_and_matcher_semantics(string $field): void
     {
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects(self::never())->method('getItem');

--- a/tests/DynamoDbRepositoryIdLookupTest.php
+++ b/tests/DynamoDbRepositoryIdLookupTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Result\BatchGetItemOutput;
+use AsyncAws\DynamoDb\Result\GetItemOutput;
+use AsyncAws\DynamoDb\Result\QueryOutput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use Broadway\ReadModel\Identifiable;
+use Broadway\ReadModel\Testing\RepositoryTestReadModel;
+use Broadway\Serializer\SimpleInterfaceSerializer;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbRepository;
+use chrisjenkinson\DynamoDbReadModel\DynamoDbRepositoryFactory;
+use chrisjenkinson\DynamoDbReadModel\Exception\InvalidIdCriterion;
+use chrisjenkinson\DynamoDbReadModel\JsonEncoder;
+use chrisjenkinson\DynamoDbReadModel\ReadModelSnapshotStore;
+use PHPUnit\Framework\TestCase;
+
+final class DynamoDbRepositoryIdLookupTest extends TestCase
+{
+    public function testScalarLowercaseIdUsesGetItemWithoutQueryingOrBatching(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('getItem')->willReturn($this->getOutput($this->model('one')));
+        $client->expects(self::never())->method('query');
+        $client->expects(self::never())->method('batchGetItem');
+
+        self::assertSame(['one'], $this->ids($this->repository($client)->findBy([
+            'id' => 'one',
+        ])));
+    }
+
+    public function testMissingScalarLowercaseIdReturnsAnEmptyList(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::once())->method('getItem')->willReturn($this->getOutput());
+        $client->expects(self::never())->method('query');
+        $client->expects(self::never())->method('batchGetItem');
+
+        self::assertSame([], $this->repository($client)->findBy([
+            'id' => 'missing',
+        ]));
+    }
+
+    public function testScalarLowercaseIdAppliesOnlyTheAdditionalPredicates(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::exactly(2))->method('getItem')->willReturn($this->getOutput($this->model('one', 'foo')));
+        $client->expects(self::never())->method('query');
+        $client->expects(self::never())->method('batchGetItem');
+        $repository = $this->repository($client);
+
+        self::assertSame(['one'], $this->ids($repository->findBy([
+            'id'  => 'one',
+            'foo' => 'foo',
+        ])));
+        self::assertSame([], $repository->findBy([
+            'id'  => 'one',
+            'foo' => 'other',
+        ]));
+    }
+
+    public function testIdListUsesBatchGetAndPreservesRequestedOrderWhileOmittingMissingModels(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::never())->method('getItem');
+        $client->expects(self::never())->method('query');
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->batchOutput([
+            $this->item($this->model('three')),
+            $this->item($this->model('one')),
+        ]));
+
+        self::assertSame(['one', 'three'], $this->ids($this->repository($client)->findBy([
+            'id' => ['one', 'missing', 'three'],
+        ])));
+    }
+
+    public function testIdListPredicatesAreAppliedOnlyToTheBatchLoadedModels(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::never())->method('getItem');
+        $client->expects(self::never())->method('query');
+        $client->expects(self::once())->method('batchGetItem')->willReturn($this->batchOutput([
+            $this->item($this->model('two', 'other')),
+            $this->item($this->model('one', 'matching')),
+        ]));
+
+        self::assertSame(['one'], $this->ids($this->repository($client)->findBy([
+            'id'  => ['one', 'two'],
+            'foo' => 'matching',
+        ])));
+    }
+
+    public function testImpossibleAndEmptyIdCriteriaReturnWithoutCallingDynamoDb(): void
+    {
+        $client     = $this->clientExpectingNoReads();
+        $repository = $this->repository($client);
+
+        self::assertSame([], $repository->findBy([]));
+        self::assertSame([], $repository->findBy([
+            'id' => null,
+        ]));
+        self::assertSame([], $repository->findBy([
+            'id' => [],
+        ]));
+    }
+
+    public function testMalformedIdListFailsBeforeCallingDynamoDb(): void
+    {
+        $repository = $this->repository($this->clientExpectingNoReads());
+        $this->expectException(InvalidIdCriterion::class);
+
+        $repository->findBy([
+            'id' => ['one', 2],
+        ]);
+    }
+
+    /**
+     * @dataProvider legacyIdFieldNames
+     */
+    public function testNonExactLowercaseIdFieldsRetainQueryAndMatcherSemantics(string $field): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::never())->method('getItem');
+        $client->expects(self::never())->method('batchGetItem');
+        $client->expects(self::once())->method('query')->willReturn($this->queryOutput($this->model('one')));
+
+        self::assertSame(['one'], $this->ids($this->repository($client)->findBy([
+            $field => 'one',
+        ])));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public function legacyIdFieldNames(): iterable
+    {
+        yield 'Id' => ['Id'];
+        yield 'ID' => ['ID'];
+    }
+
+    private function clientExpectingNoReads(): DynamoDbClient
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects(self::never())->method('getItem');
+        $client->expects(self::never())->method('batchGetItem');
+        $client->expects(self::never())->method('query');
+
+        return $client;
+    }
+
+    private function repository(DynamoDbClient $client): DynamoDbRepository
+    {
+        $repository = (new DynamoDbRepositoryFactory(
+            $client,
+            new SimpleInterfaceSerializer(),
+            'table',
+            new ReadModelSnapshotStore()
+        ))->create('repository', RepositoryTestReadModel::class);
+        self::assertInstanceOf(DynamoDbRepository::class, $repository);
+
+        return $repository;
+    }
+
+    private function model(string $id, string $foo = 'foo'): RepositoryTestReadModel
+    {
+        return new RepositoryTestReadModel($id, 'name', $foo, []);
+    }
+
+    private function getOutput(?RepositoryTestReadModel $model = null): GetItemOutput
+    {
+        $output = $this->createStub(GetItemOutput::class);
+        $output->method('getItem')
+            ->willReturn(null === $model ? [] : $this->item($model));
+
+        return $output;
+    }
+
+    /**
+     * @param array<int, array<string, AttributeValue>> $items
+     */
+    private function batchOutput(array $items): BatchGetItemOutput
+    {
+        $output = $this->createStub(BatchGetItemOutput::class);
+        $output->method('getResponses')
+            ->willReturn([
+                'table' => $items,
+            ]);
+        $output->method('getUnprocessedKeys')
+            ->willReturn([]);
+
+        return $output;
+    }
+
+    private function queryOutput(RepositoryTestReadModel $model): QueryOutput
+    {
+        $output = $this->createStub(QueryOutput::class);
+        $output->method('getCount')
+            ->willReturn(1);
+        $output->method('getItems')
+            ->willReturn([$this->item($model)]);
+
+        return $output;
+    }
+
+    /**
+     * @return array<string, AttributeValue>
+     */
+    private function item(RepositoryTestReadModel $model): array
+    {
+        return [
+            'Id' => new AttributeValue([
+                'S' => $model->getId(),
+            ]),
+            'Data' => new AttributeValue([
+                'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+            ]),
+        ];
+    }
+
+    /**
+     * @param Identifiable[] $models
+     *
+     * @return list<string>
+     */
+    private function ids(array $models): array
+    {
+        return array_map(static fn (Identifiable $model): string => $model->getId(), $models);
+    }
+}

--- a/tests/DynamoDbRepositoryResponseResolutionTest.php
+++ b/tests/DynamoDbRepositoryResponseResolutionTest.php
@@ -31,9 +31,12 @@ final class DynamoDbRepositoryResponseResolutionTest extends TestCase
     {
         $output = new PutItemOutput($this->createResponse());
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('putItem')->willReturn($output);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($output);
 
-        $this->createRepository($client)->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
+        $this->createRepository($client)
+            ->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
 
         $this->assertTrue($output->info()['resolved']);
     }
@@ -45,9 +48,12 @@ final class DynamoDbRepositoryResponseResolutionTest extends TestCase
     {
         $output = new DeleteItemOutput($this->createResponse());
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('deleteItem')->willReturn($output);
+        $client->expects($this->once())
+            ->method('deleteItem')
+            ->willReturn($output);
 
-        $this->createRepository($client)->remove('id');
+        $this->createRepository($client)
+            ->remove('id');
 
         $this->assertTrue($output->info()['resolved']);
     }

--- a/tests/DynamoDbRepositoryResponseResolutionTest.php
+++ b/tests/DynamoDbRepositoryResponseResolutionTest.php
@@ -24,10 +24,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
 
 final class DynamoDbRepositoryResponseResolutionTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function it_resolves_the_put_item_response_when_saving(): void
+    public function test_it_resolves_the_put_item_response_when_saving(): void
     {
         $output = new PutItemOutput($this->createResponse());
         $client = $this->createMock(DynamoDbClient::class);
@@ -41,10 +38,7 @@ final class DynamoDbRepositoryResponseResolutionTest extends TestCase
         $this->assertTrue($output->info()['resolved']);
     }
 
-    /**
-     * @test
-     */
-    public function it_resolves_the_delete_item_response_when_removing(): void
+    public function test_it_resolves_the_delete_item_response_when_removing(): void
     {
         $output = new DeleteItemOutput($this->createResponse());
         $client = $this->createMock(DynamoDbClient::class);

--- a/tests/DynamoDbRepositorySnapshotSuppressionTest.php
+++ b/tests/DynamoDbRepositorySnapshotSuppressionTest.php
@@ -7,6 +7,7 @@ namespace chrisjenkinson\DynamoDbReadModel\Tests;
 use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Result\BatchGetItemOutput;
 use AsyncAws\DynamoDb\Result\DeleteItemOutput;
 use AsyncAws\DynamoDb\Result\GetItemOutput;
 use AsyncAws\DynamoDb\Result\PutItemOutput;
@@ -31,9 +32,11 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $model = $repository->find('id');
         self::assertInstanceOf(RepositoryTestReadModel::class, $model);
@@ -49,9 +52,12 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($putItemOutput);
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $model = $repository->find('id');
         self::assertInstanceOf(RepositoryTestReadModel::class, $model);
@@ -64,10 +70,14 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $putItemOutput = new PutItemOutput($this->createResponse());
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('getItem');
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->never())
+            ->method('getItem');
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($putItemOutput);
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $repository->save(new RepositoryTestReadModel('id', 'name', 'foo', []));
     }
@@ -75,9 +85,11 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
     public function test_it_rejects_saving_a_read_model_for_a_different_repository_class(): void
     {
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $this->expectException(UnexpectedReadModel::class);
 
@@ -89,10 +101,13 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $putItemOutput = new PutItemOutput($this->createResponse());
 
         $client = $this->createMock(DynamoDbClient::class);
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($putItemOutput);
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
-        $model      = new RepositoryTestReadModel('id', 'name', 'foo', []);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
+        $model = new RepositoryTestReadModel('id', 'name', 'foo', []);
 
         $repository->save($model);
         $repository->save($model);
@@ -110,8 +125,9 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
                 $successfulOutput
             );
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
-        $model      = new RepositoryTestReadModel('id', 'name', 'foo', []);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
+        $model = new RepositoryTestReadModel('id', 'name', 'foo', []);
 
         try {
             $repository->save($model);
@@ -131,11 +147,16 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
-        $client->expects($this->once())->method('deleteItem')->willReturn($deleteItemOutput);
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->once())
+            ->method('deleteItem')
+            ->willReturn($deleteItemOutput);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($putItemOutput);
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
-        $model      = $repository->find('id');
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
+        $model = $repository->find('id');
         self::assertInstanceOf(RepositoryTestReadModel::class, $model);
 
         $repository->remove('id');
@@ -148,9 +169,11 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', [])));
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $this->expectException(UnexpectedReadModel::class);
 
@@ -163,7 +186,8 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
         $factory = $this->createFactory($client);
 
@@ -181,7 +205,9 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($putItemOutput);
 
         $factory = $this->createFactory($client);
 
@@ -215,7 +241,9 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('getItem')
             ->willReturn($this->getItemOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
-        $client->expects($this->once())->method('putItem')->willReturn($putItemOutput);
+        $client->expects($this->once())
+            ->method('putItem')
+            ->willReturn($putItemOutput);
 
         $factory    = $this->createFactory($client);
         $repository = $factory->create('items', RepositoryTestReadModel::class);
@@ -233,9 +261,11 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('query')
             ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $models = $repository->findAll();
         self::assertCount(1, $models);
@@ -250,9 +280,11 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('query')
             ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('id', 'name', 'foo', [])));
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $models = $repository->findBy([
             'foo' => 'foo',
@@ -269,11 +301,36 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('query')
             ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('id', 'name', 'not-matching', [])));
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         self::assertSame([], $repository->findBy([
+            'foo' => 'matching',
+        ]));
+        $repository->save(new RepositoryTestReadModel('id', 'name', 'not-matching', []));
+    }
+
+    public function test_it_snapshots_batch_loaded_models_even_when_an_additional_predicate_filters_them_out(): void
+    {
+        $client = $this->createMock(DynamoDbClient::class);
+        $client->expects($this->once())
+            ->method('batchGetItem')
+            ->willReturn($this->batchGetOutputFor(new RepositoryTestReadModel('id', 'name', 'not-matching', [])));
+        $client->expects($this->never())
+            ->method('query');
+        $client->expects($this->never())
+            ->method('getItem');
+        $client->expects($this->never())
+            ->method('putItem');
+
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
+
+        self::assertSame([], $repository->findBy([
+            'id'  => ['id'],
             'foo' => 'matching',
         ]));
         $repository->save(new RepositoryTestReadModel('id', 'name', 'not-matching', []));
@@ -285,9 +342,11 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('query')
             ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', []), 'physical-id'));
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $this->expectException(UnexpectedReadModel::class);
 
@@ -300,9 +359,11 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $client->expects($this->once())
             ->method('query')
             ->willReturn($this->queryOutputFor(new RepositoryTestReadModel('payload-id', 'name', 'foo', []), 'physical-id'));
-        $client->expects($this->never())->method('putItem');
+        $client->expects($this->never())
+            ->method('putItem');
 
-        $repository = $this->createFactory($client)->create('items', RepositoryTestReadModel::class);
+        $repository = $this->createFactory($client)
+            ->create('items', RepositoryTestReadModel::class);
 
         $this->expectException(UnexpectedReadModel::class);
 
@@ -319,11 +380,12 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
     private function getItemOutputFor(RepositoryTestReadModel $model): GetItemOutput
     {
         $output = $this->createStub(GetItemOutput::class);
-        $output->method('getItem')->willReturn([
-            'Data' => new AttributeValue([
-                'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
-            ]),
-        ]);
+        $output->method('getItem')
+            ->willReturn([
+                'Data' => new AttributeValue([
+                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                ]),
+            ]);
 
         return $output;
     }
@@ -333,17 +395,39 @@ final class DynamoDbRepositorySnapshotSuppressionTest extends TestCase
         $physicalId ??= $model->getId();
 
         $output = $this->createStub(QueryOutput::class);
-        $output->method('getCount')->willReturn(1);
-        $output->method('getItems')->willReturn([
-            [
-                'Id' => new AttributeValue([
-                    'S' => $physicalId,
-                ]),
-                'Data' => new AttributeValue([
-                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
-                ]),
-            ],
-        ]);
+        $output->method('getCount')
+            ->willReturn(1);
+        $output->method('getItems')
+            ->willReturn([
+                [
+                    'Id' => new AttributeValue([
+                        'S' => $physicalId,
+                    ]),
+                    'Data' => new AttributeValue([
+                        'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                    ]),
+                ],
+            ]);
+
+        return $output;
+    }
+
+    private function batchGetOutputFor(RepositoryTestReadModel $model): BatchGetItemOutput
+    {
+        $output = $this->createStub(BatchGetItemOutput::class);
+        $output->method('getResponses')
+            ->willReturn([
+                'table' => [[
+                    'Id' => new AttributeValue([
+                        'S' => $model->getId(),
+                    ]),
+                    'Data' => new AttributeValue([
+                        'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                    ]),
+                ]],
+            ]);
+        $output->method('getUnprocessedKeys')
+            ->willReturn([]);
 
         return $output;
     }

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -68,29 +68,69 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         ]));
     }
 
+    public function test_it_finds_a_read_model_by_exact_lowercase_id(): void
+    {
+        $model = $this->createReadModel('one', 'name', 'foo');
+        $this->repository->save($model);
+
+        self::assertEquals([$model], $this->repository->findBy([
+            'id' => 'one',
+        ]));
+    }
+
+    public function test_it_finds_an_ordered_id_list_and_omits_missing_models(): void
+    {
+        $one   = $this->createReadModel('one', 'name one', 'foo');
+        $two   = $this->createReadModel('two', 'name two', 'foo');
+        $three = $this->createReadModel('three', 'name three', 'foo');
+        $this->repository->save($one);
+        $this->repository->save($two);
+        $this->repository->save($three);
+
+        self::assertEquals([$three, $one], $this->repository->findBy([
+            'id' => ['three', 'missing', 'one'],
+        ]));
+    }
+
+    public function test_it_applies_additional_predicates_to_an_id_list(): void
+    {
+        $matching = $this->createReadModel('one', 'name one', 'matching');
+        $other    = $this->createReadModel('two', 'name two', 'other');
+        $outside  = $this->createReadModel('outside', 'name outside', 'matching');
+        $this->repository->save($matching);
+        $this->repository->save($other);
+        $this->repository->save($outside);
+
+        self::assertEquals([$matching], $this->repository->findBy([
+            'id'  => ['one', 'two'],
+            'foo' => 'matching',
+        ]));
+    }
+
     public function test_it_rejects_unexpected_serialized_classes_before_deserializing_them(): void
     {
         UnexpectedSerializableReadModel::$deserializeWasCalled = false;
 
-        $this->createDynamoDbClient()->putItem([
-            'TableName' => self::TABLE_NAME,
-            'Item'      => [
-                'Name' => new AttributeValue([
-                    'S' => self::REPOSITORY_NAME,
-                ]),
-                'Id' => new AttributeValue([
-                    'S' => 'unexpected',
-                ]),
-                'Data' => new AttributeValue([
-                    'S' => json_encode([
-                        'class'   => UnexpectedSerializableReadModel::class,
-                        'payload' => [
-                            'id' => 'unexpected',
-                        ],
-                    ], JSON_THROW_ON_ERROR),
-                ]),
-            ],
-        ])->resolve();
+        $this->createDynamoDbClient()
+            ->putItem([
+                'TableName' => self::TABLE_NAME,
+                'Item'      => [
+                    'Name' => new AttributeValue([
+                        'S' => self::REPOSITORY_NAME,
+                    ]),
+                    'Id' => new AttributeValue([
+                        'S' => 'unexpected',
+                    ]),
+                    'Data' => new AttributeValue([
+                        'S' => json_encode([
+                            'class'   => UnexpectedSerializableReadModel::class,
+                            'payload' => [
+                                'id' => 'unexpected',
+                            ],
+                        ], JSON_THROW_ON_ERROR),
+                    ]),
+                ],
+            ])->resolve();
 
         $this->expectException(UnexpectedReadModel::class);
 
@@ -103,25 +143,26 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
 
     public function test_it_rejects_serialized_data_without_a_string_class(): void
     {
-        $this->createDynamoDbClient()->putItem([
-            'TableName' => self::TABLE_NAME,
-            'Item'      => [
-                'Name' => new AttributeValue([
-                    'S' => self::REPOSITORY_NAME,
-                ]),
-                'Id' => new AttributeValue([
-                    'S' => 'invalid-class',
-                ]),
-                'Data' => new AttributeValue([
-                    'S' => json_encode([
-                        'class'   => true,
-                        'payload' => [
-                            'id' => 'invalid-class',
-                        ],
-                    ], JSON_THROW_ON_ERROR),
-                ]),
-            ],
-        ])->resolve();
+        $this->createDynamoDbClient()
+            ->putItem([
+                'TableName' => self::TABLE_NAME,
+                'Item'      => [
+                    'Name' => new AttributeValue([
+                        'S' => self::REPOSITORY_NAME,
+                    ]),
+                    'Id' => new AttributeValue([
+                        'S' => 'invalid-class',
+                    ]),
+                    'Data' => new AttributeValue([
+                        'S' => json_encode([
+                            'class'   => true,
+                            'payload' => [
+                                'id' => 'invalid-class',
+                            ],
+                        ], JSON_THROW_ON_ERROR),
+                    ]),
+                ],
+            ])->resolve();
 
         $this->expectException(UnexpectedReadModel::class);
 
@@ -193,20 +234,21 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
 
     private function putSerializedReadModel(string $physicalId, RepositoryTestReadModel $model): void
     {
-        $this->createDynamoDbClient()->putItem([
-            'TableName' => self::TABLE_NAME,
-            'Item'      => [
-                'Name' => new AttributeValue([
-                    'S' => self::REPOSITORY_NAME,
-                ]),
-                'Id' => new AttributeValue([
-                    'S' => $physicalId,
-                ]),
-                'Data' => new AttributeValue([
-                    'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
-                ]),
-            ],
-        ])->resolve();
+        $this->createDynamoDbClient()
+            ->putItem([
+                'TableName' => self::TABLE_NAME,
+                'Item'      => [
+                    'Name' => new AttributeValue([
+                        'S' => self::REPOSITORY_NAME,
+                    ]),
+                    'Id' => new AttributeValue([
+                        'S' => $physicalId,
+                    ]),
+                    'Data' => new AttributeValue([
+                        'S' => (new JsonEncoder())->encode((new SimpleInterfaceSerializer())->serialize($model)),
+                    ]),
+                ],
+            ])->resolve();
     }
 
     private function createDynamoDbClient(): DynamoDbClient

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -254,9 +254,20 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
     private function createDynamoDbClient(): DynamoDbClient
     {
         return new DynamoDbClient(Configuration::create([
-            'endpoint'        => getenv('DYNAMODB_ENDPOINT') ?: 'http://dynamodb-local:8000',
-            'accessKeyId'     => getenv('AWS_ACCESS_KEY_ID') ?: 'none',
-            'accessKeySecret' => getenv('AWS_SECRET_ACCESS_KEY') ?: 'none',
+            'endpoint'        => $this->required_environment_variable('DYNAMODB_ENDPOINT'),
+            'accessKeyId'     => $this->required_environment_variable('AWS_ACCESS_KEY_ID'),
+            'accessKeySecret' => $this->required_environment_variable('AWS_SECRET_ACCESS_KEY'),
         ]));
+    }
+
+    private function required_environment_variable(string $name): string
+    {
+        $value = getenv($name);
+
+        if (false === $value || '' === $value) {
+            throw new \RuntimeException(sprintf('Required environment variable "%s" is not set.', $name));
+        }
+
+        return $value;
     }
 }

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -254,13 +254,13 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
     private function createDynamoDbClient(): DynamoDbClient
     {
         return new DynamoDbClient(Configuration::create([
-            'endpoint'        => $this->required_environment_variable('DYNAMODB_ENDPOINT'),
-            'accessKeyId'     => $this->required_environment_variable('AWS_ACCESS_KEY_ID'),
-            'accessKeySecret' => $this->required_environment_variable('AWS_SECRET_ACCESS_KEY'),
+            'endpoint'        => $this->requiredEnvironmentVariable('DYNAMODB_ENDPOINT'),
+            'accessKeyId'     => $this->requiredEnvironmentVariable('AWS_ACCESS_KEY_ID'),
+            'accessKeySecret' => $this->requiredEnvironmentVariable('AWS_SECRET_ACCESS_KEY'),
         ]));
     }
 
-    private function required_environment_variable(string $name): string
+    private function requiredEnvironmentVariable(string $name): string
     {
         $value = getenv($name);
 

--- a/tests/FindByCriteriaTest.php
+++ b/tests/FindByCriteriaTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use chrisjenkinson\DynamoDbReadModel\Exception\InvalidIdCriterion;
+use chrisjenkinson\DynamoDbReadModel\FindByCriteria;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class FindByCriteriaTest extends TestCase
+{
+    public function test_it_classifies_supported_id_criteria(): void
+    {
+        $absent = FindByCriteria::from([
+            'name' => 'Alice',
+        ]);
+
+        self::assertFalse($absent->hasId);
+        self::assertFalse($absent->multiple);
+        self::assertFalse($absent->impossible);
+        self::assertSame([], $absent->ids);
+        self::assertSame([
+            'name' => 'Alice',
+        ], $absent->remainingFields);
+
+        $uppercaseOnly = FindByCriteria::from([
+            'ID' => 'one',
+        ]);
+
+        self::assertFalse($uppercaseOnly->hasId);
+        self::assertFalse($uppercaseOnly->multiple);
+        self::assertFalse($uppercaseOnly->impossible);
+        self::assertSame([], $uppercaseOnly->ids);
+        self::assertSame([
+            'ID' => 'one',
+        ], $uppercaseOnly->remainingFields);
+
+        $scalar = FindByCriteria::from([
+            'id'   => 'one',
+            'name' => 'Alice',
+        ]);
+
+        self::assertTrue($scalar->hasId);
+        self::assertFalse($scalar->multiple);
+        self::assertFalse($scalar->impossible);
+        self::assertSame(['one'], $scalar->ids);
+        self::assertSame([
+            'name' => 'Alice',
+        ], $scalar->remainingFields);
+
+        $emptyList = FindByCriteria::from([
+            'id'     => [],
+            'status' => 'active',
+        ]);
+
+        self::assertTrue($emptyList->hasId);
+        self::assertTrue($emptyList->multiple);
+        self::assertFalse($emptyList->impossible);
+        self::assertSame([], $emptyList->ids);
+        self::assertSame([
+            'status' => 'active',
+        ], $emptyList->remainingFields);
+
+        $list = FindByCriteria::from([
+            'id' => ['two', 'one', 'two', 'three', 'one'],
+            'ID' => 'preserved',
+        ]);
+
+        self::assertTrue($list->hasId);
+        self::assertTrue($list->multiple);
+        self::assertFalse($list->impossible);
+        self::assertSame(['two', 'one', 'three'], $list->ids);
+        self::assertSame([
+            'ID' => 'preserved',
+        ], $list->remainingFields);
+    }
+
+    public function test_it_marks_non_matching_scalar_types_as_impossible(): void
+    {
+        $resource = fopen('php://memory', 'rb');
+        self::assertIsResource($resource);
+
+        try {
+            foreach (['', 1, 1.5, true, false, null, new \stdClass(), $resource] as $value) {
+                $criteria = FindByCriteria::from([
+                    'id'   => $value,
+                    'name' => 'Alice',
+                ]);
+
+                self::assertTrue($criteria->hasId);
+                self::assertFalse($criteria->multiple);
+                self::assertTrue($criteria->impossible);
+                self::assertSame([], $criteria->ids);
+                self::assertSame([
+                    'name' => 'Alice',
+                ], $criteria->remainingFields);
+            }
+        } finally {
+            fclose($resource);
+        }
+    }
+
+    public function test_it_rejects_non_list_arrays(): void
+    {
+        try {
+            FindByCriteria::from([
+                'id' => [
+                    'first' => 'one',
+                ],
+            ]);
+            self::fail('Expected an invalid ID criterion exception.');
+        } catch (InvalidIdCriterion $exception) {
+            self::assertInstanceOf(InvalidArgumentException::class, $exception);
+            self::assertSame('non-list', $exception->reason);
+            self::assertNull($exception->index);
+            self::assertSame('array', $exception->actualType);
+            self::assertSame('The ID criterion array must be a list.', $exception->getMessage());
+        }
+    }
+
+    public function test_it_rejects_invalid_list_entries(): void
+    {
+        $invalidValues = ['', 1, 1.5, true, false, null, new \stdClass()];
+        $resource      = fopen('php://memory', 'rb');
+        self::assertIsResource($resource);
+        $invalidValues[] = $resource;
+
+        try {
+            foreach ($invalidValues as $value) {
+                try {
+                    FindByCriteria::from([
+                        'id' => ['valid', $value],
+                    ]);
+                    self::fail('Expected an invalid ID criterion exception.');
+                } catch (InvalidIdCriterion $exception) {
+                    self::assertInstanceOf(InvalidArgumentException::class, $exception);
+                    self::assertSame('invalid-entry', $exception->reason);
+                    self::assertSame(1, $exception->index);
+                    self::assertSame(get_debug_type($value), $exception->actualType);
+
+                    if ('' === $value) {
+                        self::assertSame(
+                            'The ID criterion entry at index 1 must be a non-empty string; got string.',
+                            $exception->getMessage()
+                        );
+                    }
+                }
+            }
+        } finally {
+            fclose($resource);
+        }
+    }
+}

--- a/tests/InputBuilderBatchGetItemTest.php
+++ b/tests/InputBuilderBatchGetItemTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 final class InputBuilderBatchGetItemTest extends TestCase
 {
-    public function testBuildsBatchGetItemInputForIds(): void
+    public function test_builds_batch_get_item_input_for_ids(): void
     {
         $input = (new InputBuilder())->buildBatchGetItemInput('table', 'repository', ['one', 'two']);
 
@@ -37,7 +37,7 @@ final class InputBuilderBatchGetItemTest extends TestCase
         self::assertNull($keysAndAttributes->getConsistentRead());
     }
 
-    public function testBuildsRetryInputWithSuppliedKeysAndAttributes(): void
+    public function test_builds_retry_input_with_supplied_keys_and_attributes(): void
     {
         $keysAndAttributes = new KeysAndAttributes([
             'Keys' => [

--- a/tests/InputBuilderBatchGetItemTest.php
+++ b/tests/InputBuilderBatchGetItemTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use AsyncAws\DynamoDb\Input\BatchGetItemInput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use AsyncAws\DynamoDb\ValueObject\KeysAndAttributes;
+use chrisjenkinson\DynamoDbReadModel\InputBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class InputBuilderBatchGetItemTest extends TestCase
+{
+    public function testBuildsBatchGetItemInputForIds(): void
+    {
+        $input = (new InputBuilder())->buildBatchGetItemInput('table', 'repository', ['one', 'two']);
+
+        self::assertInstanceOf(BatchGetItemInput::class, $input);
+        self::assertSame(['table'], array_keys($input->getRequestItems()));
+
+        $keysAndAttributes = $input->getRequestItems()['table'];
+        $keys              = $keysAndAttributes->getKeys();
+
+        self::assertCount(2, $keys);
+        self::assertSame(['Name', 'Id'], array_keys($keys[0]));
+        self::assertSame('repository', $keys[0]['Name']->getS());
+        self::assertSame('one', $keys[0]['Id']->getS());
+        self::assertSame(['Name', 'Id'], array_keys($keys[1]));
+        self::assertSame('repository', $keys[1]['Name']->getS());
+        self::assertSame('two', $keys[1]['Id']->getS());
+        self::assertSame('#Id, #Data', $keysAndAttributes->getProjectionExpression());
+        self::assertSame([
+            '#Id'   => 'Id',
+            '#Data' => 'Data',
+        ], $keysAndAttributes->getExpressionAttributeNames());
+        self::assertNull($keysAndAttributes->getConsistentRead());
+    }
+
+    public function testBuildsRetryInputWithSuppliedKeysAndAttributes(): void
+    {
+        $keysAndAttributes = new KeysAndAttributes([
+            'Keys' => [
+                [
+                    'Name' => new AttributeValue([
+                        'S' => 'repository',
+                    ]),
+                    'Id' => new AttributeValue([
+                        'S' => 'one',
+                    ]),
+                ],
+            ],
+        ]);
+
+        $input = (new InputBuilder())->buildBatchGetItemRetryInput('table', $keysAndAttributes);
+
+        self::assertInstanceOf(BatchGetItemInput::class, $input);
+        self::assertSame(['table'], array_keys($input->getRequestItems()));
+        self::assertSame($keysAndAttributes, $input->getRequestItems()['table']);
+    }
+}


### PR DESCRIPTION
ID-constrained `findBy()` calls now use bounded DynamoDB reads instead of querying and filtering the entire repository partition.

- Use `GetItem` for scalar IDs and chunked `BatchGetItem` for ID lists.
- Preserve requested order, deduplicate IDs, retry unprocessed keys with bounded backoff, and retain validation and snapshot protections.
- Apply additional predicates only to loaded IDs while preserving existing non-ID and deferred-repository behavior.

The README documents the efficient ID paths and the remaining full-partition cost of arbitrary non-indexed criteria.