### PR TITLE
Upgrade to PHPStan 2 and level 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5.0",
         "symplify/easy-coding-standard": "^11.1.0 || ^12.0.0 || ^13.0.0",
-        "phpstan/phpstan": "^1.8.0",
+        "phpstan/phpstan": "^2.2",
         "infection/infection": "^0.26.0 || ^0.32.0"
     },
     "license": "GPL-3.0-or-later",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 8
+	level: 10
 	paths:
 		- src
 		- tests

--- a/src/DeferredDynamoDbRepository.php
+++ b/src/DeferredDynamoDbRepository.php
@@ -41,7 +41,7 @@ final class DeferredDynamoDbRepository implements FlushableRepository
 
     public function find($id): ?Identifiable
     {
-        $id = (string) $id;
+        $id = RepositoryId::normalize($id);
 
         if (in_array($id, $this->removed, true)) {
             return null;
@@ -187,7 +187,7 @@ final class DeferredDynamoDbRepository implements FlushableRepository
 
     public function remove($id): void
     {
-        $id = (string) $id;
+        $id = RepositoryId::normalize($id);
 
         unset($this->managed[$id], $this->dirty[$id]);
 

--- a/src/DynamoDbReadModelStorage.php
+++ b/src/DynamoDbReadModelStorage.php
@@ -247,10 +247,10 @@ final class DynamoDbReadModelStorage
     }
 
     /**
-     * @param array<string, array<int, array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue>>> $responses
-     * @param list<string>                                                                              $outstandingIds
+     * @param array<string, array<array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue>>> $responses
+     * @param list<string>                                                                         $outstandingIds
      *
-     * @return array<int, array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue>>
+     * @return array<array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue>>
      */
     private function validateResponses(array $responses, array $outstandingIds): array
     {
@@ -337,7 +337,7 @@ final class DynamoDbReadModelStorage
     }
 
     /**
-     * @param array<string, mixed> $serializedData
+     * @param array<mixed> $serializedData
      */
     private function deserializeSerializedReadModel(array $serializedData, string $observedId, bool $rememberSnapshot): Identifiable
     {
@@ -352,7 +352,7 @@ final class DynamoDbReadModelStorage
         $data = $this->serializer->deserialize($serializedData);
 
         if (!($data instanceof $this->class && $data instanceof Identifiable)) {
-            throw new UnexpectedReadModel(actual: $data::class, expected: $this->class);
+            throw new UnexpectedReadModel(actual: get_debug_type($data), expected: $this->class);
         }
 
         $id = $data->getId();

--- a/src/DynamoDbRepository.php
+++ b/src/DynamoDbRepository.php
@@ -22,7 +22,7 @@ final class DynamoDbRepository implements Repository
 
     public function find($id): ?Identifiable
     {
-        return $this->storage->find((string) $id);
+        return $this->storage->find(RepositoryId::normalize($id));
     }
 
     /**
@@ -81,6 +81,6 @@ final class DynamoDbRepository implements Repository
 
     public function remove($id): void
     {
-        $this->storage->remove((string) $id);
+        $this->storage->remove(RepositoryId::normalize($id));
     }
 }

--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -11,6 +11,12 @@ final class JsonDecoder
      */
     public function decode(string $json): array
     {
-        return json_decode($json, flags: JSON_THROW_ON_ERROR | JSON_OBJECT_AS_ARRAY);
+        $decoded = json_decode($json, flags: JSON_THROW_ON_ERROR | JSON_OBJECT_AS_ARRAY);
+
+        if (!is_array($decoded)) {
+            throw new \JsonException('Decoded JSON did not produce an array.');
+        }
+
+        return $decoded;
     }
 }

--- a/src/PreparedReadModelSave.php
+++ b/src/PreparedReadModelSave.php
@@ -7,7 +7,7 @@ namespace chrisjenkinson\DynamoDbReadModel;
 final class PreparedReadModelSave
 {
     /**
-     * @param array<string, mixed> $serializedData
+     * @param array<mixed> $serializedData
      */
     public function __construct(
         public readonly string $id,

--- a/src/ReadModelSnapshot.php
+++ b/src/ReadModelSnapshot.php
@@ -33,12 +33,6 @@ final class ReadModelSnapshot
 
     public static function keyFor(string $table, string $name, string $class, string $id): string
     {
-        $key = json_encode([$table, $name, $class, $id], JSON_THROW_ON_ERROR);
-
-        if (!is_string($key)) {
-            throw new \JsonException('Snapshot key encoding did not produce a string.');
-        }
-
-        return $key;
+        return json_encode([$table, $name, $class, $id], JSON_THROW_ON_ERROR);
     }
 }

--- a/src/RepositoryId.php
+++ b/src/RepositoryId.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel;
+
+/**
+ * @internal
+ */
+final class RepositoryId
+{
+    public static function normalize(mixed $id): string
+    {
+        if (null === $id || is_scalar($id) || $id instanceof \Stringable) {
+            return (string) $id;
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'Repository ID must be scalar, null, or Stringable; got %s.',
+            get_debug_type($id)
+        ));
+    }
+}

--- a/tests/DeferredDynamoDbRepositoryTest.php
+++ b/tests/DeferredDynamoDbRepositoryTest.php
@@ -8,6 +8,7 @@ use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\BatchGetItemInput;
+use AsyncAws\DynamoDb\Input\DeleteItemInput;
 use AsyncAws\DynamoDb\Input\PutItemInput;
 use AsyncAws\DynamoDb\Result\BatchGetItemOutput;
 use AsyncAws\DynamoDb\Result\DeleteItemOutput;
@@ -138,7 +139,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects($this->once())
             ->method('putItem')
-            ->willReturnCallback(function ($input) use (&$writtenPayloads, $putItemOutput): PutItemOutput {
+            ->willReturnCallback(function (PutItemInput $input) use (&$writtenPayloads, $putItemOutput): PutItemOutput {
                 $writtenPayloads[] = $this->decodePutItemPayload($input);
 
                 return $putItemOutput;
@@ -161,7 +162,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects($this->once())
             ->method('putItem')
-            ->willReturnCallback(function ($input) use (&$writtenPayloads, $putItemOutput): PutItemOutput {
+            ->willReturnCallback(function (PutItemInput $input) use (&$writtenPayloads, $putItemOutput): PutItemOutput {
                 $writtenPayloads[] = $this->decodePutItemPayload($input);
 
                 return $putItemOutput;
@@ -309,7 +310,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects($this->exactly(2))
             ->method('deleteItem')
-            ->willReturnCallback(function ($input) use (&$deletedIds): DeleteItemOutput {
+            ->willReturnCallback(function (DeleteItemInput $input) use (&$deletedIds): DeleteItemOutput {
                 $deletedIds[] = $input->getKey()['Id']->getS();
 
                 return new DeleteItemOutput($this->createResponse());
@@ -950,7 +951,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects($this->exactly(4))
             ->method('putItem')
-            ->willReturnCallback(function ($input) use (&$attemptedIds): PutItemOutput {
+            ->willReturnCallback(function (PutItemInput $input) use (&$attemptedIds): PutItemOutput {
                 $id = $input->getItem()['Id']
                     ->getS();
                 $attemptedIds[] = $id;
@@ -1021,7 +1022,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
         $client = $this->createMock(DynamoDbClient::class);
         $client->expects($this->exactly(4))
             ->method('deleteItem')
-            ->willReturnCallback(function ($input) use (&$attemptedRemoves): DeleteItemOutput {
+            ->willReturnCallback(function (DeleteItemInput $input) use (&$attemptedRemoves): DeleteItemOutput {
                 $id = $input->getKey()['Id']
                     ->getS();
                 $attemptedRemoves[] = $id;
@@ -1195,7 +1196,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
      */
     private function modelIds(array $models): array
     {
-        return array_map(static fn (Identifiable $model): string => $model->getId(), $models);
+        return array_values(array_map(static fn (Identifiable $model): string => $model->getId(), $models));
     }
 
     private function createResponse(): Response
@@ -1206,7 +1207,7 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
     }
 
     /**
-     * @return array<mixed>
+     * @return array{payload: array{name: string}}
      */
     private function decodePutItemPayload(PutItemInput $input): array
     {
@@ -1214,7 +1215,14 @@ final class DeferredDynamoDbRepositoryTest extends TestCase
             ->getS();
         self::assertIsString($data);
 
-        return json_decode($data, true, flags: JSON_THROW_ON_ERROR);
+        $decoded = json_decode($data, true, flags: JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        self::assertArrayHasKey('payload', $decoded);
+        self::assertIsArray($decoded['payload']);
+        self::assertArrayHasKey('name', $decoded['payload']);
+        self::assertIsString($decoded['payload']['name']);
+
+        return $decoded;
     }
 
     private function stringableId(string $id): object

--- a/tests/DynamoDbReadModelStorageBatchGetIntegrationTest.php
+++ b/tests/DynamoDbReadModelStorageBatchGetIntegrationTest.php
@@ -132,7 +132,7 @@ final class DynamoDbReadModelStorageBatchGetIntegrationTest extends TestCase
      */
     private function modelIds(array $models): array
     {
-        return array_map(static fn (Identifiable $model): string => $model->getId(), $models);
+        return array_values(array_map(static fn (Identifiable $model): string => $model->getId(), $models));
     }
 
     private function newStorage(): DynamoDbReadModelStorage

--- a/tests/DynamoDbRepositoryIdLookupTest.php
+++ b/tests/DynamoDbRepositoryIdLookupTest.php
@@ -228,6 +228,6 @@ final class DynamoDbRepositoryIdLookupTest extends TestCase
      */
     private function ids(array $models): array
     {
-        return array_map(static fn (Identifiable $model): string => $model->getId(), $models);
+        return array_values(array_map(static fn (Identifiable $model): string => $model->getId(), $models));
     }
 }

--- a/tests/DynamoDbRepositoryTest.php
+++ b/tests/DynamoDbRepositoryTest.php
@@ -44,8 +44,8 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
 
     public function test_it_removes_only_one_read_model_when_multiple_are_saved(): void
     {
-        $model1 = $this->createReadModel('1', 'name1', 'foo1');
-        $model2 = $this->createReadModel('2', 'name2', 'foo2');
+        $model1 = $this->readModel('1', 'name1', 'foo1');
+        $model2 = $this->readModel('2', 'name2', 'foo2');
 
         $this->repository->save($model1);
         $this->repository->save($model2);
@@ -57,8 +57,8 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
 
     public function test_it_finds_read_models_by_public_getter(): void
     {
-        $model1 = $this->createReadModel('1', 'name1', 'foo1');
-        $model2 = $this->createReadModel('2', 'name2', 'foo2');
+        $model1 = $this->readModel('1', 'name1', 'foo1');
+        $model2 = $this->readModel('2', 'name2', 'foo2');
 
         $this->repository->save($model1);
         $this->repository->save($model2);
@@ -70,7 +70,7 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
 
     public function test_it_finds_a_read_model_by_exact_lowercase_id(): void
     {
-        $model = $this->createReadModel('one', 'name', 'foo');
+        $model = $this->readModel('one', 'name', 'foo');
         $this->repository->save($model);
 
         self::assertEquals([$model], $this->repository->findBy([
@@ -80,9 +80,9 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
 
     public function test_it_finds_an_ordered_id_list_and_omits_missing_models(): void
     {
-        $one   = $this->createReadModel('one', 'name one', 'foo');
-        $two   = $this->createReadModel('two', 'name two', 'foo');
-        $three = $this->createReadModel('three', 'name three', 'foo');
+        $one   = $this->readModel('one', 'name one', 'foo');
+        $two   = $this->readModel('two', 'name two', 'foo');
+        $three = $this->readModel('three', 'name three', 'foo');
         $this->repository->save($one);
         $this->repository->save($two);
         $this->repository->save($three);
@@ -94,9 +94,9 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
 
     public function test_it_applies_additional_predicates_to_an_id_list(): void
     {
-        $matching = $this->createReadModel('one', 'name one', 'matching');
-        $other    = $this->createReadModel('two', 'name two', 'other');
-        $outside  = $this->createReadModel('outside', 'name outside', 'matching');
+        $matching = $this->readModel('one', 'name one', 'matching');
+        $other    = $this->readModel('two', 'name two', 'other');
+        $outside  = $this->readModel('outside', 'name outside', 'matching');
         $this->repository->save($matching);
         $this->repository->save($other);
         $this->repository->save($outside);
@@ -230,6 +230,11 @@ final class DynamoDbRepositoryTest extends RepositoryTestCase
         $this->repository->findBy([
             'foo' => 'foo',
         ]);
+    }
+
+    private function readModel(string $id, string $name, string $foo): RepositoryTestReadModel
+    {
+        return new RepositoryTestReadModel($id, $name, $foo, []);
     }
 
     private function putSerializedReadModel(string $physicalId, RepositoryTestReadModel $model): void

--- a/tests/JsonDecoderTest.php
+++ b/tests/JsonDecoderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use chrisjenkinson\DynamoDbReadModel\JsonDecoder;
+use JsonException;
+use PHPUnit\Framework\TestCase;
+
+final class JsonDecoderTest extends TestCase
+{
+    public function test_it_decodes_json_objects_as_arrays(): void
+    {
+        self::assertSame([
+            'key' => 'value',
+        ], (new JsonDecoder())->decode('{"key":"value"}'));
+    }
+
+    public function test_it_rejects_json_that_does_not_decode_to_an_array(): void
+    {
+        $this->expectException(JsonException::class);
+        $this->expectExceptionMessage('Decoded JSON did not produce an array.');
+
+        (new JsonDecoder())->decode('"value"');
+    }
+}

--- a/tests/RepositoryIdTest.php
+++ b/tests/RepositoryIdTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace chrisjenkinson\DynamoDbReadModel\Tests;
+
+use chrisjenkinson\DynamoDbReadModel\RepositoryId;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+final class RepositoryIdTest extends TestCase
+{
+    public function test_it_preserves_broadway_string_conversion_for_supported_ids(): void
+    {
+        $stringable = new class() implements \Stringable {
+            public function __toString(): string
+            {
+                return 'stringable';
+            }
+        };
+
+        self::assertSame('id', RepositoryId::normalize('id'));
+        self::assertSame('123', RepositoryId::normalize(123));
+        self::assertSame('1.5', RepositoryId::normalize(1.5));
+        self::assertSame('1', RepositoryId::normalize(true));
+        self::assertSame('', RepositoryId::normalize(false));
+        self::assertSame('', RepositoryId::normalize(null));
+        self::assertSame('stringable', RepositoryId::normalize($stringable));
+    }
+
+    public function test_it_rejects_ids_that_php_cannot_safely_convert_to_strings(): void
+    {
+        $resource = fopen('php://memory', 'rb');
+        self::assertIsResource($resource);
+
+        try {
+            foreach ([[1], new \stdClass(), $resource] as $id) {
+                try {
+                    RepositoryId::normalize($id);
+                    self::fail('Expected an invalid repository ID exception.');
+                } catch (InvalidArgumentException $exception) {
+                    self::assertSame(
+                        sprintf('Repository ID must be scalar, null, or Stringable; got %s.', get_debug_type($id)),
+                        $exception->getMessage()
+                    );
+                }
+            }
+        } finally {
+            fclose($resource);
+        }
+    }
+}


### PR DESCRIPTION
Upgrade the maintainer toolchain to PHPStan 2.2 and raise static analysis from level 8 to level 10. The stricter analysis exposed mixed-value boundaries that are now handled without a baseline or suppressions.

- Validate Broadway repository IDs and decoded JSON before unsafe operations
- Align Broadway and Async AWS collection contracts with their upstream types
- Add precise test callback and helper types while leaving PHPUnit and Infection unchanged

Supersedes #20.