### PR TITLE
Update Infection for supported PHP versions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           tools: composer
           coverage: xdebug
 
@@ -139,9 +139,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vendor
-          key: ${{ runner.os }}-php-8.4-infection-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-php-8.5-infection-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-infection-
+            ${{ runner.os }}-php-8.5-infection-
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "phpunit/phpunit": "^9.5.0",
         "symplify/easy-coding-standard": "^11.1.0 || ^12.0.0 || ^13.0.0",
         "phpstan/phpstan": "^2.2",
-        "infection/infection": "^0.26.0 || ^0.32.0"
+        "infection/infection": "^0.32.0 || ^0.34.0"
     },
     "license": "GPL-3.0-or-later",
     "autoload": {


### PR DESCRIPTION
Replace the historical Infection 0.26 fallback with deliberate tool versions for the supported PHP platforms. Composer can now use the newest compatible Infection release without making PHP 8.2 development installs fail.

- PHP 8.2 resolves Infection 0.32.6
- PHP 8.3 and newer resolve Infection 0.34
- Run the single mutation-testing job on PHP 8.5 and leave PHPUnit unchanged

Supersedes #33.