### PR TITLE
Run ECS on PHP 8.5

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           tools: composer
           coverage: none
 
@@ -101,9 +101,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: vendor
-          key: ${{ runner.os }}-php-8.4-ecs-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-php-8.5-ecs-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-php-8.4-ecs-
+            ${{ runner.os }}-php-8.5-ecs-
 
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress


### PR DESCRIPTION
Move the dedicated ECS job to the highest PHP version supported by the repository and keep its dependency cache isolated by runtime version.

- Run ECS on PHP 8.5
- Update the exact and restore cache keys to PHP 8.5
- Leave the build and Infection jobs unchanged