### PR TITLE
Upgrade DynamoDB Local to 3.3.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       dynamodb-local:
-        image: amazon/dynamodb-local:1.22.0
+        image: amazon/dynamodb-local:3.3.0
         ports:
           - 8000:8000/tcp
     strategy:
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       dynamodb-local:
-        image: amazon/dynamodb-local:1.22.0
+        image: amazon/dynamodb-local:3.3.0
         ports:
           - 8000:8000/tcp
     env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   dynamodb-local:
-    image: amazon/dynamodb-local:1.22.0
+    image: amazon/dynamodb-local:3.3.0
     ports:
       - "8000:8000"
   


### PR DESCRIPTION
Move local development and CI from the legacy DynamoDB Local 1.x line to the explicitly pinned 3.3.0 release.

- Update the Docker Compose service image
- Update the build-matrix and Infection service images
- Keep the existing ports and DynamoDB endpoints unchanged